### PR TITLE
JWT 인증 방식 개선 - refresh token 도입

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,47 @@
 # 미니타닥!!
 
-### 미니 타닥???
+### 🔥 미니 타닥???
 
-[타닥타닥](https://github.com/boostcampwm-2021/web15-TadakTadak) 의 간소화 버전입니다.
+> [타닥타닥](https://github.com/boostcampwm-2021/web15-TadakTadak) 의 간소화 버전입니다.
 
+- 기존 프로젝트의 복습을 위한 프로젝트입니다.
 - 기존 프론트 코드 재활용도 하면서 새 기술들을 적용해 볼 예정입니다.
 - 타닥타닥 프로젝트 서버 코드를 로컬에서 이용하여 개발합니다.
+
+### 🔥 기술 스택
+
+- JS - React, TypeScript
+- CSS - [AdorableCSS](https://www.npmjs.com/package/adorable-css)
+- 실시간통신 - [Agora](https://www.agora.io/en/), socket.io
+- 이외에도 적용할 기술이 추가될 수 있습니다.
+
+### 각 페이지 소개
+
+#### 🦀 로그인 페이지
+
+<img width="800" alt="image" src="https://user-images.githubusercontent.com/67041709/183837840-16f33b2d-ac56-4add-9cc0-ec7effceecc0.png">
+
+- `아이디 / 비밀번호` 로그인
+- 로그인 요청시 기존 서버에서 요구하는 `email / password` 형식에 맞게 변환 후 요청
+
+#### 🦀 회원가입 페이지
+
+<img width="800" alt="image" src="https://user-images.githubusercontent.com/67041709/183845169-cb111aab-7249-4bcc-bc2f-c8c29c2ede7e.png">
+
+- `아이디 / 비밀번호` 회원가입
+- 회원가입 요청시 기존 서버에서 요구하는 `email / nickname / password / devField` 형식에 맞게 변환 후 요청
+
+#### 🦀 페이지 추가 예정
+
+comming soon.......... 🙂🙂🙂🙂🙂🙂🙂
+
+### ☠️ 프로젝트를 통해 맛 볼 기술
+
+- 기존 jwt 방식에 refresh token 추가 도입
+- 함수형 프로그래밍 및 선언형 프로그래밍 맛보기
+- adorable css
+- event delegation
+- intersection observer
+- state management library
+- suspense + errorboundary
+- 이외에도 추가될 수 있습니다.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@
 - 실시간통신 - [Agora](https://www.agora.io/en/), socket.io
 - 이외에도 적용할 기술이 추가될 수 있습니다.
 
+### 몇가지 고민의 흔적
+
+- [인증 방식 개선 - refresh token 도입하기](https://tar-keyboard-2bc.notion.site/JWT-596bf75945f64a46b5b6fd01fc640c98)
+- 추가될 예정입니다.
+
 ### 각 페이지 소개
 
 #### 🦀 로그인 페이지

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/react-dom": "^18.0.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-loading": "^2.0.3",
         "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.1",
         "typescript": "^4.7.4",
@@ -13773,6 +13774,15 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "node_modules/react-loading": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/react-loading/-/react-loading-2.0.3.tgz",
+      "integrity": "sha512-Vdqy79zq+bpeWJqC+xjltUjuGApyoItPgL0vgVfcJHhqwU7bAMKzysfGW/ADu6i0z0JiOCRJjo+IkFNkRNbA3A==",
+      "peerDependencies": {
+        "prop-types": "^15.6.0",
+        "react": ">=0.14.0"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -26246,6 +26256,12 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "react-loading": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/react-loading/-/react-loading-2.0.3.tgz",
+      "integrity": "sha512-Vdqy79zq+bpeWJqC+xjltUjuGApyoItPgL0vgVfcJHhqwU7bAMKzysfGW/ADu6i0z0JiOCRJjo+IkFNkRNbA3A==",
+      "requires": {}
     },
     "react-refresh": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/react-dom": "^18.0.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-loading": "^2.0.3",
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
     "typescript": "^4.7.4",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,13 +3,17 @@ import MainLayout from './components/layout/MainLayout';
 import Router from './components/Router';
 import { auth } from './apis/auth';
 import { useNavigate } from 'react-router-dom';
+import { getUserByToken } from './apis';
 
 function App() {
   const navigate = useNavigate();
 
   const getUser = useCallback(async () => {
-    await auth.requestAccessToken();
-    navigate('/main');
+    const { isOk, data } = await getUserByToken();
+    if (isOk && data) {
+      auth.setAccessToken(data.token);
+      navigate('/main');
+    }
   }, [navigate]);
 
   useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,23 @@
+import { useCallback, useEffect } from 'react';
 import MainLayout from './components/layout/MainLayout';
 import Router from './components/Router';
+import { auth } from './apis/auth';
+import { useNavigate } from 'react-router-dom';
 
 function App() {
+  const navigate = useNavigate();
+
+  const getUser = useCallback(async () => {
+    await auth.requestAccessToken();
+    navigate('/main');
+  }, [navigate]);
+
+  useEffect(() => {
+    if (!auth.hasAccessToken()) {
+      getUser();
+    }
+  }, [getUser]);
+
   return (
     <div className="App">
       <MainLayout>

--- a/src/apis/apiUtils.ts
+++ b/src/apis/apiUtils.ts
@@ -1,6 +1,5 @@
-import 'dotenv/config';
-
 const baseUrl = process.env.REACT_APP_SERVER_URL ?? '';
+
 const TAKE_ROOM_UNIT = 15;
 
 type TypeRoom = '타닥타닥' | '캠프파이어';

--- a/src/apis/apiUtils.ts
+++ b/src/apis/apiUtils.ts
@@ -1,0 +1,39 @@
+import 'dotenv/config';
+
+const baseUrl = process.env.REACT_APP_SERVER_URL ?? '';
+const TAKE_ROOM_UNIT = 15;
+
+type TypeRoom = '타닥타닥' | '캠프파이어';
+
+export function getUrl(url: string): string {
+  return baseUrl + url;
+}
+
+export function queryObjToString<T>(queryObj: T): string {
+  return Object.entries(queryObj)
+    .map((e) => e.join('='))
+    .join('&');
+}
+
+interface QueryObj {
+  type: TypeRoom;
+  search: string;
+  take: number;
+  page: number;
+}
+
+interface GetRoomQueryFnProps {
+  type: TypeRoom;
+  search: string;
+  page: number;
+}
+
+export function getRoomQueryObj({ type, search, page }: GetRoomQueryFnProps): QueryObj {
+  const queryObj = {
+    type,
+    search,
+    take: TAKE_ROOM_UNIT,
+    page,
+  };
+  return queryObj;
+}

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,0 +1,56 @@
+import { getUserByToken } from './index';
+
+export type SetTokenParams = {
+  accessToken: string;
+  now: number;
+  expiredAt: number;
+};
+
+export const auth = (function () {
+  let _token: string | null | undefined = null;
+  let _serverTime = null;
+  let _expiredTime: number | null = null;
+
+  function validateToken() {
+    if (!_token) return false;
+    if (!_expiredTime) return false;
+
+    const current = Date.now();
+    const restTime = Math.floor((_expiredTime - current) / 1000);
+
+    return restTime >= 180;
+  }
+
+  return {
+    hasAccessToken() {
+      if (!validateToken()) {
+        this.clearAccessToken();
+      }
+      return _token ?? false;
+    },
+    setAccessToken({ accessToken, now, expiredAt }: SetTokenParams) {
+      _token = accessToken;
+      _serverTime = now;
+      _expiredTime = expiredAt;
+    },
+    clearAccessToken() {
+      _token = null;
+      _serverTime = null;
+      _expiredTime = null;
+    },
+    async getHeader() {
+      const isValid = validateToken();
+      if (!isValid) {
+        await this.requestAccessToken();
+      }
+      return { Authorization: `Bearer ${_token}` };
+    },
+    async requestAccessToken() {
+      const { isOk, data } = await getUserByToken();
+      if (isOk && data) {
+        this.setAccessToken(data.token);
+        return;
+      }
+    },
+  };
+})();

--- a/src/apis/fetchFns.ts
+++ b/src/apis/fetchFns.ts
@@ -1,0 +1,34 @@
+import { HTTPResponse } from '../types';
+import { getOptions, postOptions, patchOptions, deleteOptions, BodyType } from './options';
+import fetcher from './fetcher';
+import { getUrl } from './apiUtils';
+
+export async function fetchGet<T>(url: string, query = ''): Promise<HTTPResponse<T>> {
+  const path = query ? `${url}?${query}` : url;
+  const requestUrl = getUrl(path);
+  const response = await fetcher<T>(requestUrl, getOptions());
+  return response;
+}
+
+export async function fetchPost<T>(url: string, body: BodyType = {}): Promise<HTTPResponse<T>> {
+  const requestUrl = getUrl(url);
+  const response = await fetcher<T>(requestUrl, postOptions(body));
+  return response;
+}
+
+export async function fetchPatch<T>(url: string, body: BodyType = {}): Promise<HTTPResponse<T>> {
+  const requestUrl = getUrl(url);
+  const response = await fetcher<T>(requestUrl, patchOptions(body));
+  return response;
+}
+
+export function fetchDelete(url: string): void {
+  const requestUrl = getUrl(url);
+  fetcher(requestUrl, deleteOptions());
+}
+
+export async function fetchDeleteImage<T>(url: string): Promise<HTTPResponse<T>> {
+  const requestUrl = getUrl(url);
+  const response = await fetcher<T>(requestUrl, deleteOptions());
+  return response;
+}

--- a/src/apis/fetchFns.ts
+++ b/src/apis/fetchFns.ts
@@ -3,32 +3,38 @@ import { getOptions, postOptions, patchOptions, deleteOptions, BodyType } from '
 import fetcher from './fetcher';
 import { getUrl } from './apiUtils';
 
-export async function fetchGet<T>(url: string, query = ''): Promise<HTTPResponse<T>> {
+export async function fetchGet<T>(url: string, query = '', isAuth = false): Promise<HTTPResponse<T>> {
   const path = query ? `${url}?${query}` : url;
   const requestUrl = getUrl(path);
-  const response = await fetcher<T>(requestUrl, getOptions());
+  const options = (await getOptions(isAuth)) as RequestInit;
+  const response = await fetcher<T>(requestUrl, options);
   return response;
 }
 
-export async function fetchPost<T>(url: string, body: BodyType = {}): Promise<HTTPResponse<T>> {
+export async function fetchPost<T>(url: string, body: BodyType = {}, isAuth = false): Promise<HTTPResponse<T>> {
   const requestUrl = getUrl(url);
-  const response = await fetcher<T>(requestUrl, postOptions(body));
+  const options = (await postOptions(body, isAuth)) as RequestInit;
+  const response = await fetcher<T>(requestUrl, options);
   return response;
 }
 
-export async function fetchPatch<T>(url: string, body: BodyType = {}): Promise<HTTPResponse<T>> {
+export async function fetchPatch<T>(url: string, body: BodyType = {}, isAuth = false): Promise<HTTPResponse<T>> {
   const requestUrl = getUrl(url);
-  const response = await fetcher<T>(requestUrl, patchOptions(body));
+  const options = (await patchOptions(body, isAuth)) as RequestInit;
+  const response = await fetcher<T>(requestUrl, options);
   return response;
 }
 
-export function fetchDelete(url: string): void {
+export async function fetchDelete<T>(url: string, isAuth = false): Promise<HTTPResponse<T>> {
   const requestUrl = getUrl(url);
-  fetcher(requestUrl, deleteOptions());
+  const options = (await deleteOptions(isAuth)) as RequestInit;
+  const response = await fetcher<T>(requestUrl, options);
+  return response;
 }
 
-export async function fetchDeleteImage<T>(url: string): Promise<HTTPResponse<T>> {
+export async function fetchDeleteImage<T>(url: string, isAuth = false): Promise<HTTPResponse<T>> {
   const requestUrl = getUrl(url);
-  const response = await fetcher<T>(requestUrl, deleteOptions());
+  const options = (await deleteOptions(isAuth)) as RequestInit;
+  const response = await fetcher<T>(requestUrl, options);
   return response;
 }

--- a/src/apis/fetcher.ts
+++ b/src/apis/fetcher.ts
@@ -1,0 +1,23 @@
+import { HTTPResponse } from '../types';
+
+export default async function fetcher<T>(url: string, options: RequestInit): Promise<HTTPResponse<T>> {
+  try {
+    const response = await fetch(url, options);
+    const { statusCode, data, message } = await response.json();
+    const isOk = response.ok;
+
+    if (isOk) {
+      const res = { isOk, data };
+      return res;
+    }
+
+    throw new Error(message);
+  } catch (e: any) {
+    return {
+      isOk: false,
+      errorData: {
+        message: e.message,
+      },
+    };
+  }
+}

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -22,8 +22,8 @@ export const postLogin = async (body: PostLogin): Promise<HTTPResponse<PostLogin
   return response;
 };
 
-export const postLogout = async (isAuth: boolean): Promise<HTTPResponse<boolean>> => {
-  const response = await fetchPost<boolean>('/api/auth/logout', undefined, isAuth);
+export const postLogout = async (): Promise<HTTPResponse<boolean>> => {
+  const response = await fetchPost<boolean>('/api/auth/logout', undefined, true);
   return response;
 };
 

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -8,8 +8,17 @@ interface PostLogin {
   password: string;
 }
 
-export const postLogin = async (body: PostLogin): Promise<HTTPResponse<UserType>> => {
-  const response = await fetchPost<UserType>('/api/auth/login', { ...body });
+interface PostLoginResponse {
+  userInfo: UserType;
+  token: {
+    accessToken: string;
+    now: number;
+    expiredAt: number;
+  };
+}
+
+export const postLogin = async (body: PostLogin): Promise<HTTPResponse<PostLoginResponse>> => {
+  const response = await fetchPost<PostLoginResponse>('/api/auth/login', { ...body });
   return response;
 };
 
@@ -58,8 +67,8 @@ export const deleteImage = async (): Promise<HTTPResponse<UserType>> => {
   return response;
 };
 
-export const getUserByToken = async (): Promise<HTTPResponse<UserType>> => {
-  const response = await fetchGet<UserType>('/api/auth/token');
+export const getUserByToken = async (): Promise<HTTPResponse<PostLoginResponse>> => {
+  const response = await fetchGet<PostLoginResponse>('/api/auth/token');
   return response;
 };
 

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,0 +1,146 @@
+import { UserType, RoomType, HTTPResponse } from '../types';
+import { queryObjToString, getUrl } from './apiUtils';
+import { fetchGet, fetchPost, fetchPatch, fetchDelete, fetchDeleteImage } from './fetchFns';
+import fetcher from './fetcher';
+
+interface PostLogin {
+  email: string;
+  password: string;
+}
+
+export const postLogin = async (body: PostLogin): Promise<HTTPResponse<UserType>> => {
+  const response = await fetchPost<UserType>('/api/auth/login', { ...body });
+  return response;
+};
+
+export const postLogout = async (): Promise<HTTPResponse<boolean>> => {
+  const response = await fetchPost<boolean>('/api/auth/logout');
+  return response;
+};
+
+interface PostJoin extends PostLogin {
+  nickname: string;
+}
+
+export const postJoin = async (body: PostJoin): Promise<HTTPResponse<boolean>> => {
+  const response = await fetchPost<boolean>('/api/auth/join', { ...body });
+  return response;
+};
+
+export const getVisitCount = async (): Promise<HTTPResponse<number>> => {
+  const response = await fetchGet<number>('/api/history');
+  return response;
+};
+
+interface PatchUpdate {
+  originalName: string;
+  nickname: string;
+  devField?: number;
+}
+
+export const patchUpdate = async (body: PatchUpdate): Promise<HTTPResponse<UserType>> => {
+  const response = await fetchPatch<UserType>(`/api/user`, { ...body });
+  return response;
+};
+
+export const postAvatar = async (formData: FormData): Promise<HTTPResponse<UserType>> => {
+  const url = getUrl('/api/user/image');
+  const response = await fetcher<UserType>(url, {
+    method: 'POST',
+    body: formData,
+    credentials: 'include',
+  });
+  return response;
+};
+
+export const deleteImage = async (): Promise<HTTPResponse<UserType>> => {
+  const response = await fetchDeleteImage<UserType>('/api/user/image');
+  return response;
+};
+
+export const getUserByToken = async (): Promise<HTTPResponse<UserType>> => {
+  const response = await fetchGet<UserType>('/api/auth/token');
+  return response;
+};
+
+interface PostRoom {
+  userId?: number;
+  title: string;
+  description: string | null;
+  maxHeadcount: number;
+  roomType: string;
+}
+
+export const postRoom = async (body: PostRoom): Promise<HTTPResponse<RoomType>> => {
+  const response = await fetchPost<RoomType>('/api/room', { ...body });
+  return response;
+};
+
+interface GetRoomQueryObj {
+  type: string;
+  search?: string;
+  take: number;
+  page: number;
+}
+
+interface ResponseGetRoomData {
+  pageTotal: number;
+  results: RoomType[];
+  total: number;
+}
+
+export const getRoom = async (queryObj: GetRoomQueryObj): Promise<HTTPResponse<ResponseGetRoomData>> => {
+  const queryString = queryObjToString(queryObj);
+  const response = await fetchGet<ResponseGetRoomData>('/api/room', queryString);
+  return response;
+};
+
+export const getRoomByUuid = async (uuid: string): Promise<HTTPResponse<RoomType>> => {
+  const response = await fetchGet<RoomType>(`/api/room/${uuid}`);
+  return response;
+};
+
+interface DeleteRoom {
+  uuid: string;
+}
+
+export const deleteRoom = ({ uuid }: DeleteRoom): void => fetchDelete(`/api/room/${uuid}`);
+
+export const postEnterRoom = async (uuid: string): Promise<HTTPResponse<boolean>> => {
+  const response = await fetchPost<boolean>(`/api/room/${uuid}/join`);
+  return response;
+};
+
+export const postLeaveRoom = async (uuid: string): Promise<HTTPResponse<boolean>> => {
+  const response = await fetchPost<boolean>(`/api/room/${uuid}/leave`);
+  return response;
+};
+
+interface GetDevField {
+  id: string;
+  name: string;
+}
+
+export const getDevField = async (): Promise<HTTPResponse<GetDevField[]>> => {
+  const response = await fetchGet<GetDevField[]>(`/api/field`);
+  return response;
+};
+
+interface UserLogList {
+  id: number;
+  checkIn: string;
+}
+
+export const getUserLogList = async (): Promise<HTTPResponse<UserLogList[]>> => {
+  const response = await fetchGet<UserLogList[]>('/api/user/log/year');
+  return response;
+};
+
+interface UserLogListPerMonth {
+  [key: string]: number;
+}
+
+export const getUserLogListPerMonth = async (): Promise<HTTPResponse<UserLogListPerMonth>> => {
+  const response = await fetchGet<UserLogListPerMonth>('/api/user/log/month');
+  return response;
+};

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -22,8 +22,8 @@ export const postLogin = async (body: PostLogin): Promise<HTTPResponse<PostLogin
   return response;
 };
 
-export const postLogout = async (): Promise<HTTPResponse<boolean>> => {
-  const response = await fetchPost<boolean>('/api/auth/logout');
+export const postLogout = async (isAuth: boolean): Promise<HTTPResponse<boolean>> => {
+  const response = await fetchPost<boolean>('/api/auth/logout', undefined, isAuth);
   return response;
 };
 
@@ -113,7 +113,8 @@ interface DeleteRoom {
   uuid: string;
 }
 
-export const deleteRoom = ({ uuid }: DeleteRoom): void => fetchDelete(`/api/room/${uuid}`);
+export const deleteRoom = ({ uuid }: DeleteRoom): Promise<HTTPResponse<boolean>> =>
+  fetchDelete(`/api/room/${uuid}`, true);
 
 export const postEnterRoom = async (uuid: string): Promise<HTTPResponse<boolean>> => {
   const response = await fetchPost<boolean>(`/api/room/${uuid}/join`);

--- a/src/apis/options.ts
+++ b/src/apis/options.ts
@@ -1,9 +1,16 @@
+import { auth } from './auth';
+
 const emailTail = process.env.REACT_APP_EMAIL_TAIL;
 const pwdTail = process.env.REACT_APP_PWD_TAIL;
 
 export type BodyType = {
   [key: string]: string | number | null;
 };
+
+async function getAuthHeader(isAuth: boolean) {
+  if (!isAuth) return {};
+  return await auth.getHeader();
+}
 
 export function userBaseLoginOptions(userId: string, password: string) {
   return {
@@ -21,48 +28,57 @@ export function userBaseJoinOptions(userId: string, password: string) {
   };
 }
 
-export function simpleOptions(method: string): RequestInit {
+export async function simpleOptions(method: string, isAuth: boolean) {
+  const authHeader = await getAuthHeader(isAuth);
+
   return {
     method,
     headers: {
       Accept: 'application/json',
+      ...authHeader,
     },
     credentials: 'include',
   };
 }
 
-export function getOptions(): RequestInit {
-  return simpleOptions('GET');
+export function getOptions(isAuth = false) {
+  return simpleOptions('GET', isAuth);
 }
 
-export function postOptions(body: BodyType): RequestInit {
+export async function postOptions(body: BodyType, isAuth = false) {
+  const authHeader = await getAuthHeader(isAuth);
+
   return Object.keys(body).length
     ? {
         method: 'POST',
         headers: {
           Accept: 'application/json',
           'Content-Type': 'application/json',
+          ...authHeader,
         },
         credentials: 'include',
         body: JSON.stringify(body),
       }
-    : simpleOptions('POST');
+    : simpleOptions('POST', false);
 }
 
-export function patchOptions(body: BodyType): RequestInit {
+export async function patchOptions(body: BodyType, isAuth = false) {
+  const authHeader = await getAuthHeader(isAuth);
+
   return Object.keys(body).length
     ? {
         method: 'PATCH',
         headers: {
           Accept: 'application/json',
           'Content-Type': 'application/json',
+          ...authHeader,
         },
         credentials: 'include',
         body: JSON.stringify(body),
       }
-    : simpleOptions('PATCH');
+    : simpleOptions('PATCH', false);
 }
 
-export function deleteOptions(): RequestInit {
-  return simpleOptions('DELETE');
+export function deleteOptions(isAuth = false) {
+  return simpleOptions('DELETE', isAuth);
 }

--- a/src/apis/options.ts
+++ b/src/apis/options.ts
@@ -28,9 +28,7 @@ export function userBaseJoinOptions(userId: string, password: string) {
   };
 }
 
-export async function simpleOptions(method: string, isAuth: boolean) {
-  const authHeader = await getAuthHeader(isAuth);
-
+export async function simpleOptions(method: string, authHeader = {}) {
   return {
     method,
     headers: {
@@ -41,8 +39,9 @@ export async function simpleOptions(method: string, isAuth: boolean) {
   };
 }
 
-export function getOptions(isAuth = false) {
-  return simpleOptions('GET', isAuth);
+export async function getOptions(isAuth = false) {
+  const authHeader = await getAuthHeader(isAuth);
+  return simpleOptions('GET', authHeader);
 }
 
 export async function postOptions(body: BodyType, isAuth = false) {
@@ -59,7 +58,7 @@ export async function postOptions(body: BodyType, isAuth = false) {
         credentials: 'include',
         body: JSON.stringify(body),
       }
-    : simpleOptions('POST', false);
+    : simpleOptions('POST', authHeader);
 }
 
 export async function patchOptions(body: BodyType, isAuth = false) {
@@ -76,9 +75,11 @@ export async function patchOptions(body: BodyType, isAuth = false) {
         credentials: 'include',
         body: JSON.stringify(body),
       }
-    : simpleOptions('PATCH', false);
+    : simpleOptions('PATCH', authHeader);
 }
 
-export function deleteOptions(isAuth = false) {
-  return simpleOptions('DELETE', isAuth);
+export async function deleteOptions(isAuth = false) {
+  const authHeader = await getAuthHeader(isAuth);
+
+  return simpleOptions('DELETE', authHeader);
 }

--- a/src/apis/options.ts
+++ b/src/apis/options.ts
@@ -1,6 +1,25 @@
+const emailTail = process.env.REACT_APP_EMAIL_TAIL;
+const pwdTail = process.env.REACT_APP_PWD_TAIL;
+
 export type BodyType = {
   [key: string]: string | number | null;
 };
+
+export function userBaseLoginOptions(userId: string, password: string) {
+  return {
+    email: `${userId}${emailTail}`,
+    password: `${password}${pwdTail}`,
+  };
+}
+
+export function userBaseJoinOptions(userId: string, password: string) {
+  return {
+    email: `${userId}${emailTail}`,
+    password: `${password}${pwdTail}`,
+    nickname: userId,
+    devField: 1,
+  };
+}
 
 export function simpleOptions(method: string): RequestInit {
   return {

--- a/src/apis/options.ts
+++ b/src/apis/options.ts
@@ -1,0 +1,49 @@
+export type BodyType = {
+  [key: string]: string | number | null;
+};
+
+export function simpleOptions(method: string): RequestInit {
+  return {
+    method,
+    headers: {
+      Accept: 'application/json',
+    },
+    credentials: 'include',
+  };
+}
+
+export function getOptions(): RequestInit {
+  return simpleOptions('GET');
+}
+
+export function postOptions(body: BodyType): RequestInit {
+  return Object.keys(body).length
+    ? {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+        body: JSON.stringify(body),
+      }
+    : simpleOptions('POST');
+}
+
+export function patchOptions(body: BodyType): RequestInit {
+  return Object.keys(body).length
+    ? {
+        method: 'PATCH',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+        body: JSON.stringify(body),
+      }
+    : simpleOptions('PATCH');
+}
+
+export function deleteOptions(): RequestInit {
+  return simpleOptions('DELETE');
+}

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -1,0 +1,14 @@
+import ReactLoading from 'react-loading';
+
+type LoaderProps = {
+  isWholeScreen?: boolean;
+  color?: string;
+};
+
+export default function Loader({ isWholeScreen = false, color = '#75bfff' }: LoaderProps): JSX.Element {
+  return (
+    <div className={'w(100%) h(20%) text-center ' + isWholeScreen && 'fixed top(0) left(0) height(100%)'}>
+      <ReactLoading type="spin" color={color} />
+    </div>
+  );
+}

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 import Login from '../pages/Login';
 import Join from '../pages/Join';
 import Main from '../pages/Main';
@@ -6,13 +6,11 @@ import MiniTadak from '../pages/MiniTadak';
 
 export default function Router() {
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Login />} />
-        <Route path="/join" element={<Join />} />
-        <Route path="/main" element={<Main />} />
-        <Route path="/room/:uuid" element={<MiniTadak />} />
-      </Routes>
-    </BrowserRouter>
+    <Routes>
+      <Route path="/" element={<Login />} />
+      <Route path="/join" element={<Join />} />
+      <Route path="/main" element={<Main />} />
+      <Route path="/room/:uuid" element={<MiniTadak />} />
+    </Routes>
   );
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './index.css';
 import reportWebVitals from './reportWebVitals';
@@ -7,7 +8,9 @@ import reportWebVitals from './reportWebVitals';
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>,
 );
 

--- a/src/pages/Join.tsx
+++ b/src/pages/Join.tsx
@@ -2,6 +2,9 @@ import { useNavigate } from 'react-router';
 import AuthFormLayout from '../components/layout/AuthFormLayout';
 import RectButton from '../components/common/RectButton';
 import useInput from '../hooks/useInput';
+import { userBaseJoinOptions } from '../apis/options';
+import { postJoin } from '../apis';
+import { isEmpty } from '../utils/utils';
 
 const linkOption = {
   to: '/',
@@ -13,17 +16,8 @@ export default function Join() {
   const [userId, onChangeUserId] = useInput('');
   const [password, onChangePassword] = useInput('');
 
-  const isEmpty = (input: string) => {
-    if (input === '') {
-      alert('빈칸을 모두 채워주세요.');
-      return true;
-    }
-
-    return false;
-  };
-
   const redirectLoginPage = (userId: string) => {
-    navigate('/', { state: { userId } });
+    navigate('/', { state: userId });
   };
 
   const onSubmitForm = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -35,21 +29,10 @@ export default function Join() {
       return;
     }
 
-    const userBaseJoinOption = {
-      email: `${userId}@mini.tadak`,
-      password: `${password}1234@`,
-      nickname: userId,
-      devField: 1,
-    };
-    const res = await fetch('/api/auth/join', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(userBaseJoinOption),
-    });
-    const { statusCode } = await res.json();
-    if (statusCode === 201) redirectLoginPage(userId);
+    const baseOption = userBaseJoinOptions(userId, password);
+    const { isOk } = await postJoin(baseOption);
+
+    if (isOk) redirectLoginPage(userId);
     else alert('회원가입 오류');
   };
 
@@ -63,16 +46,17 @@ export default function Join() {
         <div>
           <label htmlFor="user_password">비밀번호</label>
           <input
-            type="current-password"
+            type="password"
             value={password}
             onChange={onChangePassword}
             id="user_password"
             className="m(0/5/0/5)"
             maxLength={12}
+            autoComplete="on"
           />
         </div>
       </div>
-      <RectButton buttonName="로그인" w="70" h="70" />
+      <RectButton buttonName="회원가입" w="70" h="70" />
     </AuthFormLayout>
   );
 }

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -4,8 +4,8 @@ import { userBaseLoginOptions } from '../apis/options';
 import RectButton from '../components/common/RectButton';
 import AuthFormLayout from '../components/layout/AuthFormLayout';
 import useInput from '../hooks/useInput';
-import { UserType } from '../types';
 import { isEmpty } from '../utils/utils';
+import { auth } from '../apis/auth';
 
 const linkOption = {
   to: '/join',
@@ -19,9 +19,7 @@ export default function Login() {
   const [userId, onChangeUserId] = useInput(passedUserId ?? '');
   const [password, onChangePassword] = useInput('');
 
-  const goToMain = (userData: UserType | undefined) => {
-    navigate('/main', { state: { userData } });
-  };
+  const goToMain = () => navigate('/main');
 
   const onSubmitForm = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -34,8 +32,10 @@ export default function Login() {
 
     const baseOption = userBaseLoginOptions(userId, password);
     const { isOk, data } = await postLogin(baseOption);
-
-    if (isOk) goToMain(data);
+    if (isOk && data) {
+      auth.setAccessToken(data.token);
+      goToMain();
+    }
   };
 
   return (

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,31 +1,26 @@
-import { useNavigate } from 'react-router';
+import { useNavigate, useLocation } from 'react-router';
+import { postLogin } from '../apis';
+import { userBaseLoginOptions } from '../apis/options';
 import RectButton from '../components/common/RectButton';
 import AuthFormLayout from '../components/layout/AuthFormLayout';
 import useInput from '../hooks/useInput';
 import { UserType } from '../types';
-
-type LoginProps = {};
+import { isEmpty } from '../utils/utils';
 
 const linkOption = {
   to: '/join',
   text: '회원가입 하러가기',
 };
 
-export default function Login({}: LoginProps) {
+export default function Login() {
   const navigate = useNavigate();
-  const [userId, onChangeUserId] = useInput('');
+  const location = useLocation();
+  const passedUserId = location.state as string;
+  const [userId, onChangeUserId] = useInput(passedUserId ?? '');
   const [password, onChangePassword] = useInput('');
 
-  const goToMain = (userData: UserType) => {
+  const goToMain = (userData: UserType | undefined) => {
     navigate('/main', { state: { userData } });
-  };
-
-  const isEmpty = (userId: string) => {
-    if (userId === '') {
-      return true;
-    }
-
-    return false;
   };
 
   const onSubmitForm = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -37,24 +32,10 @@ export default function Login({}: LoginProps) {
       return;
     }
 
-    const userBaseLoginOption = {
-      email: `${userId}@mini.tadak`,
-      password: `${password}1234@`,
-    };
+    const baseOption = userBaseLoginOptions(userId, password);
+    const { isOk, data } = await postLogin(baseOption);
 
-    const res = await fetch('/api/auth/login', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      credentials: 'include',
-      body: JSON.stringify(userBaseLoginOption),
-    });
-    const { statusCode, data } = await res.json();
-
-    if (statusCode === 201) {
-      goToMain(data);
-    }
+    if (isOk) goToMain(data);
   };
 
   return (
@@ -67,12 +48,13 @@ export default function Login({}: LoginProps) {
         <div>
           <label htmlFor="user_password">비밀번호</label>
           <input
-            type="current-password"
+            type="password"
             value={password}
             onChange={onChangePassword}
             id="user_password"
             className="m(0/5/0/5)"
             maxLength={12}
+            autoComplete="on"
           />
         </div>
       </div>

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import Header from '../components/Header';
 import RoomCard from '../components/RoomCard';

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -5,6 +5,7 @@ import RoomCard from '../components/RoomCard';
 import MakeRoom from '../components/MakeRoom';
 import { RoomType } from '../types';
 import { auth } from '../apis/auth';
+import { postLogout } from '../apis';
 
 export default function Main() {
   const navigate = useNavigate();
@@ -14,6 +15,12 @@ export default function Main() {
   const redirectLoginPage = useCallback(() => {
     navigate('/', { replace: true });
   }, [navigate]);
+
+  const onClickLogOut = useCallback(() => {
+    postLogout();
+    auth.clearAccessToken();
+    redirectLoginPage();
+  }, [redirectLoginPage]);
 
   const enterClickedRoom = useCallback(
     (uuid: string, roomInfo: RoomType) => {
@@ -73,7 +80,7 @@ export default function Main() {
 
   return (
     <main className="vbox">
-      <Header onClickLogOut={redirectLoginPage} userId={'유저 상태 추가후 수정예정'} />
+      <Header onClickLogOut={onClickLogOut} userId={'유저 상태 추가후 수정예정'} />
       <MakeRoom userId={'유저 상태 추가후 수정예정'} enterRoom={enterClickedRoom} />
       <div className="space(30)"></div>
       <hr className="b(1/solid/white)" />

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,18 +1,13 @@
 import { useCallback, useEffect, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import Header from '../components/Header';
 import RoomCard from '../components/RoomCard';
 import MakeRoom from '../components/MakeRoom';
 import { RoomType } from '../types';
-
-type LocationState = {
-  userId: string;
-};
+import { auth } from '../apis/auth';
 
 export default function Main() {
   const navigate = useNavigate();
-  const location = useLocation();
-  const loginUser = location.state as LocationState;
   const [loading, setLoading] = useState(true);
   const [rooms, setRooms] = useState<RoomType[]>([]);
 
@@ -64,11 +59,11 @@ export default function Main() {
   );
 
   useEffect(() => {
-    if (!loginUser) {
+    if (!auth.hasAccessToken()) {
       redirectLoginPage();
       return;
     }
-  }, [loginUser, navigate, redirectLoginPage]);
+  }, [navigate, redirectLoginPage]);
 
   useEffect(() => {
     fetchRoomList();
@@ -78,8 +73,8 @@ export default function Main() {
 
   return (
     <main className="vbox">
-      <Header onClickLogOut={redirectLoginPage} userId={loginUser.userId} />
-      <MakeRoom userId={loginUser.userId} enterRoom={enterClickedRoom} />
+      <Header onClickLogOut={redirectLoginPage} userId={'유저 상태 추가후 수정예정'} />
+      <MakeRoom userId={'유저 상태 추가후 수정예정'} enterRoom={enterClickedRoom} />
       <div className="space(30)"></div>
       <hr className="b(1/solid/white)" />
       <div className="space(30)"></div>

--- a/src/types/httpResponse.ts
+++ b/src/types/httpResponse.ts
@@ -1,0 +1,8 @@
+export default interface HTTPResponse<T> {
+  isOk: boolean;
+  errorData?: {
+    message: string;
+    statusCode?: number;
+  };
+  data?: T;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,6 @@
 import { DevFieldType } from './devField';
 import RoomType from './room';
 import UserType from './user';
+import HTTPResponse from './httpResponse';
 
-export type { DevFieldType, RoomType, UserType };
+export type { DevFieldType, RoomType, UserType, HTTPResponse };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -15,6 +15,15 @@ export const isPassword = (password: string): boolean => {
   return regExp.test(password);
 };
 
+export const isEmpty = (str: string) => {
+  if (str === '') {
+    alert('빈칸을 모두 채워주세요.');
+    return true;
+  }
+
+  return false;
+};
+
 export const getPrevYear = (now: Date, number: number): Date => {
   const tomorrow = new Date(now.setDate(now.getDate() + 1));
   const prevYear = new Date(tomorrow.setFullYear(tomorrow.getFullYear() - number));


### PR DESCRIPTION
자세한 내용은 README.md에서의 [인증 방식 개선 - refresh token 도입하기](https://tar-keyboard-2bc.notion.site/JWT-596bf75945f64a46b5b6fd01fc640c98) 참고

개선사항
- /api/auth/login : 로그인 시 액세스, 리프레시 토큰 생성 후 응답
- payload에 액세스토큰, 유저정보 응답, cookie에 리프레시 토큰 응답
- 리프레시 토큰을 DB에 저장
- @JwtAccessGuard : 권한이 필요한 요청시 액세스토큰 기반 유저 인증
- /api/auth/token : 액세스토큰 만료시 리프레시 토큰 기반 액세스토큰 발급
- 로그인 유지시 리프레시 토큰 기반 액세스토큰 발급 및 유저정보 가져오기
- 리프레시 토큰 기반 요청시, DB에 저장된 기존 토큰과 비교하여 동일한 유저인지 검증
- 서버 요청 전에, 클라이언트에서 먼저 액세스토큰 유효기간을 검증하고 토큰이 없거나 만료되었다면 액세스토큰을 먼저 발급 후 본 요청 수행
- /api/auth/logout : 로그아웃 시 리프레시 토큰 쿠키 제거, DB 리프레시 토큰 제거, 클라이언트에서 액세스토큰 삭제