### PR TITLE
Fix: App.tsx에서 기본적으로 수행하는 리프레시 작업 개선

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import MainLayout from './components/layout/MainLayout';
 import Router from './components/Router';
 import { auth } from './apis/auth';
-import { useNavigate } from 'react-router-dom';
+import { LocalStorage } from './utils/localStorage';
 import { getUserByToken } from './apis';
 
 function App() {
@@ -17,6 +18,7 @@ function App() {
   }, [navigate]);
 
   useEffect(() => {
+    if (!LocalStorage.validateAuthFlag()) return;
     if (!auth.hasAccessToken()) {
       getUser();
     }

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,3 +1,4 @@
+import { LocalStorage } from '../utils/localStorage';
 import { getUserByToken } from './index';
 
 export type SetTokenParams = {
@@ -6,7 +7,7 @@ export type SetTokenParams = {
   expiredAt: number;
 };
 
-export const auth = (function () {
+export const auth = (function (setAuthFlag, clearAuthFlag) {
   let _token: string | null | undefined = null;
   let _serverTime = null;
   let _expiredTime: number | null = null;
@@ -29,11 +30,15 @@ export const auth = (function () {
       return _token ?? false;
     },
     setAccessToken({ accessToken, now, expiredAt }: SetTokenParams) {
+      setAuthFlag();
+
       _token = accessToken;
       _serverTime = now;
       _expiredTime = expiredAt;
     },
     clearAccessToken() {
+      clearAuthFlag();
+
       _token = null;
       _serverTime = null;
       _expiredTime = null;
@@ -53,4 +58,4 @@ export const auth = (function () {
       }
     },
   };
-})();
+})(LocalStorage.setAuthFlag, LocalStorage.removeAuthFlag);

--- a/src/utils/localStorage.ts
+++ b/src/utils/localStorage.ts
@@ -1,0 +1,13 @@
+export const LocalStorage = (function () {
+  const setAuthFlag = () => localStorage.setItem('auth', 'auth');
+
+  const removeAuthFlag = () => localStorage.removeItem('auth');
+
+  const validateAuthFlag = () => {
+    const authFlag = localStorage.getItem('auth');
+    if (!authFlag) return false;
+    return true;
+  };
+
+  return { setAuthFlag, removeAuthFlag, validateAuthFlag };
+})();


### PR DESCRIPTION
- 로그인, 토큰인증시 로컬스토리지에 auth flag 생성
- auth flag가 있을 때, 리프레시 작업을 수행하도록 변경
- auth flag가 없다면, 로그인한 이력이 없다고 생각하여 새로고침시에 리프레시작업 수행하지 않음
- auth flag는 로그아웃시 제거.
- 사이트 접속시 항상 리프레시를 위한 /token 요청을 보내는 것을 막도록 함