### PR TITLE
미니타닥방 생성 및 아고라기반 영상,음성 송출, 기존 모달 개선

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/node": "^16.11.47",
         "@types/react": "^18.0.17",
         "@types/react-dom": "^18.0.6",
+        "agora-rtc-react": "^1.1.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-loading": "^2.0.3",
@@ -4371,6 +4372,33 @@
       "engines": {
         "node": ">= 6.0.0"
       }
+    },
+    "node_modules/agora-rtc-react": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/agora-rtc-react/-/agora-rtc-react-1.1.3.tgz",
+      "integrity": "sha512-AgmDoeLoL3xC7u60lTehHi1GvHsP8l09CX3bn+NyHx6E0Dmbbxdtqkn+YrlakWa4IYOAn0d/9oKvuGrNtUiOpA==",
+      "dependencies": {
+        "agora-rtc-sdk-ng": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/agora-rtc-sdk-ng": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/agora-rtc-sdk-ng/-/agora-rtc-sdk-ng-4.13.0.tgz",
+      "integrity": "sha512-+ZVVPgaSbAVjTREbOtyyfhVyJ24dgvTug68kFFRDxEhSuGHqReOwS8obwJiDmH9JvYhc8CzuWWwAebWEmbupsg==",
+      "dependencies": {
+        "agora-rte-extension": "^1.0.22"
+      }
+    },
+    "node_modules/agora-rte-extension": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/agora-rte-extension/-/agora-rte-extension-1.1.0.tgz",
+      "integrity": "sha512-HGsr7dJ5FHeCVHTLHCUfQ6cvKVLJz9b11F/FZbSQ/IqYlGZwRdu5E6hVdWenjWyYiqmpZm+nCP9IIqXSA+BPwA=="
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -19663,6 +19691,27 @@
       "requires": {
         "debug": "4"
       }
+    },
+    "agora-rtc-react": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/agora-rtc-react/-/agora-rtc-react-1.1.3.tgz",
+      "integrity": "sha512-AgmDoeLoL3xC7u60lTehHi1GvHsP8l09CX3bn+NyHx6E0Dmbbxdtqkn+YrlakWa4IYOAn0d/9oKvuGrNtUiOpA==",
+      "requires": {
+        "agora-rtc-sdk-ng": "^4.3.0"
+      }
+    },
+    "agora-rtc-sdk-ng": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/agora-rtc-sdk-ng/-/agora-rtc-sdk-ng-4.13.0.tgz",
+      "integrity": "sha512-+ZVVPgaSbAVjTREbOtyyfhVyJ24dgvTug68kFFRDxEhSuGHqReOwS8obwJiDmH9JvYhc8CzuWWwAebWEmbupsg==",
+      "requires": {
+        "agora-rte-extension": "^1.0.22"
+      }
+    },
+    "agora-rte-extension": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/agora-rte-extension/-/agora-rte-extension-1.1.0.tgz",
+      "integrity": "sha512-HGsr7dJ5FHeCVHTLHCUfQ6cvKVLJz9b11F/FZbSQ/IqYlGZwRdu5E6hVdWenjWyYiqmpZm+nCP9IIqXSA+BPwA=="
     },
     "ajv": {
       "version": "6.12.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "agora-rtc-react": "^1.1.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^4.4.0",
         "react-loading": "^2.0.3",
         "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.1",
@@ -13803,6 +13804,14 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
+    "node_modules/react-icons": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.4.0.tgz",
+      "integrity": "sha512-fSbvHeVYo/B5/L4VhB7sBA1i2tS8MkT0Hb9t2H1AVPkwGfVHLJCqyr2Py9dKMxsyM63Eng1GkdZfbWj+Fmv8Rg==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -26330,6 +26339,12 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "react-icons": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.4.0.tgz",
+      "integrity": "sha512-fSbvHeVYo/B5/L4VhB7sBA1i2tS8MkT0Hb9t2H1AVPkwGfVHLJCqyr2Py9dKMxsyM63Eng1GkdZfbWj+Fmv8Rg==",
+      "requires": {}
     },
     "react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "agora-rtc-react": "^1.1.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^4.4.0",
     "react-loading": "^2.0.3",
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@types/node": "^16.11.47",
     "@types/react": "^18.0.17",
     "@types/react-dom": "^18.0.6",
+    "agora-rtc-react": "^1.1.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-loading": "^2.0.3",

--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,7 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <div id="modal-root"></div>
     <script src="https://unpkg.com/adorable-css"></script>
   </body>
 </html>

--- a/src/agora/ScreenShare.tsx
+++ b/src/agora/ScreenShare.tsx
@@ -1,0 +1,52 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { IAgoraRTCClient, ICameraVideoTrack } from 'agora-rtc-react';
+import { getScreenVideoTrack } from './config';
+
+interface ScreenShareProps {
+  client: IAgoraRTCClient;
+  videoTrack: ICameraVideoTrack;
+  trackState: { video: boolean; audio: boolean };
+  shutDownScreenShare: () => void;
+}
+
+const ScreenShare = ({ client, videoTrack, trackState, shutDownScreenShare }: ScreenShareProps): JSX.Element => {
+  const { ready, tracks, error } = getScreenVideoTrack();
+  const firstRenderRef = useRef(true);
+
+  const publishScreenShare = useCallback(async () => {
+    await client.unpublish(videoTrack);
+    await client.publish(tracks);
+
+    if (!Array.isArray(tracks)) {
+      tracks.on('track-ended', async () => {
+        await client.unpublish(tracks);
+        tracks.close();
+        if (trackState.video) {
+          await client.publish(videoTrack);
+        }
+        shutDownScreenShare();
+      });
+    }
+  }, [client, videoTrack, tracks, trackState, shutDownScreenShare]);
+
+  useEffect(() => {
+    if (ready && tracks) publishScreenShare();
+    if (error) shutDownScreenShare();
+
+    return () => {
+      if (firstRenderRef.current) {
+        firstRenderRef.current = false;
+        return;
+      }
+
+      if (!error && !Array.isArray(tracks)) {
+        client.unpublish(tracks);
+        tracks.close();
+      }
+    };
+  }, [client, ready, tracks, error, videoTrack, publishScreenShare, shutDownScreenShare]);
+
+  return <div></div>;
+};
+
+export default ScreenShare;

--- a/src/agora/config.ts
+++ b/src/agora/config.ts
@@ -1,0 +1,36 @@
+import {
+  createClient,
+  ClientConfig,
+  createMicrophoneAndCameraTracks,
+  createMicrophoneAudioTrack,
+  createScreenVideoTrack,
+  ILocalAudioTrack,
+  ILocalVideoTrack,
+  AgoraRTCError,
+} from 'agora-rtc-react';
+import { SCREEN_SHARE_HEIGHT } from '../utils/constant';
+
+const config: ClientConfig = {
+  mode: 'rtc',
+  codec: 'vp8',
+};
+
+const useClient = createClient(config);
+const useMicrophoneAndCameraTracks = createMicrophoneAndCameraTracks();
+const useMicrophoneTrack = createMicrophoneAudioTrack();
+const useScreenVideoTrack = (): {
+  ready: boolean;
+  tracks: ILocalVideoTrack | [ILocalVideoTrack, ILocalAudioTrack];
+  error: AgoraRTCError | null;
+} => {
+  const screenShare = createScreenVideoTrack(
+    {
+      encoderConfig: `${SCREEN_SHARE_HEIGHT}p_1`,
+      optimizationMode: 'detail',
+    },
+    'disable',
+  );
+  return screenShare();
+};
+
+export { useClient, useMicrophoneAndCameraTracks, useMicrophoneTrack, useScreenVideoTrack };

--- a/src/agora/config.ts
+++ b/src/agora/config.ts
@@ -7,30 +7,34 @@ import {
   ILocalAudioTrack,
   ILocalVideoTrack,
   AgoraRTCError,
+  ScreenVideoTrackInitConfig,
 } from 'agora-rtc-react';
 import { SCREEN_SHARE_HEIGHT } from '../utils/constant';
 
-const config: ClientConfig = {
+type ScreenShareReturnType = {
+  ready: boolean;
+  tracks: ILocalVideoTrack | [ILocalVideoTrack, ILocalAudioTrack];
+  error: AgoraRTCError | null;
+};
+
+const clientConfig: ClientConfig = {
   mode: 'rtc',
   codec: 'vp8',
 };
 
-const getClient = createClient(config);
-const getMicrophoneAndCameraTracks = createMicrophoneAndCameraTracks();
-const getMicrophoneTrack = createMicrophoneAudioTrack();
-const getScreenVideoTrack = (): {
-  ready: boolean;
-  tracks: ILocalVideoTrack | [ILocalVideoTrack, ILocalAudioTrack];
-  error: AgoraRTCError | null;
-} => {
-  const screenShare = createScreenVideoTrack(
-    {
-      encoderConfig: `${SCREEN_SHARE_HEIGHT}p_1`,
-      optimizationMode: 'detail',
-    },
-    'disable',
-  );
-  return screenShare();
+const screenShareConfig: ScreenVideoTrackInitConfig = {
+  encoderConfig: `${SCREEN_SHARE_HEIGHT}p_1`,
+  optimizationMode: 'detail',
 };
+const screenShareWithVideo = 'disable';
+
+const getClient = createClient(clientConfig);
+
+const getMicrophoneAndCameraTracks = createMicrophoneAndCameraTracks();
+
+const getMicrophoneTrack = createMicrophoneAudioTrack();
+
+const getScreenVideoTrack = (): ScreenShareReturnType =>
+  createScreenVideoTrack(screenShareConfig, screenShareWithVideo)();
 
 export { getClient, getMicrophoneAndCameraTracks, getMicrophoneTrack, getScreenVideoTrack };

--- a/src/agora/config.ts
+++ b/src/agora/config.ts
@@ -15,10 +15,10 @@ const config: ClientConfig = {
   codec: 'vp8',
 };
 
-const useClient = createClient(config);
-const useMicrophoneAndCameraTracks = createMicrophoneAndCameraTracks();
-const useMicrophoneTrack = createMicrophoneAudioTrack();
-const useScreenVideoTrack = (): {
+const getClient = createClient(config);
+const getMicrophoneAndCameraTracks = createMicrophoneAndCameraTracks();
+const getMicrophoneTrack = createMicrophoneAudioTrack();
+const getScreenVideoTrack = (): {
   ready: boolean;
   tracks: ILocalVideoTrack | [ILocalVideoTrack, ILocalAudioTrack];
   error: AgoraRTCError | null;
@@ -33,4 +33,4 @@ const useScreenVideoTrack = (): {
   return screenShare();
 };
 
-export { useClient, useMicrophoneAndCameraTracks, useMicrophoneTrack, useScreenVideoTrack };
+export { getClient, getMicrophoneAndCameraTracks, getMicrophoneTrack, getScreenVideoTrack };

--- a/src/agora/util.ts
+++ b/src/agora/util.ts
@@ -1,11 +1,12 @@
 import { IAgoraRTCClient, IAgoraRTCRemoteUser, ICameraVideoTrack, IMicrophoneAudioTrack } from 'agora-rtc-sdk-ng';
+import { PAGE_NAME } from '../utils/constant';
 
 export const userPublished = (
   agoraType: string,
   client: IAgoraRTCClient,
   setState: (user: IAgoraRTCRemoteUser) => void,
 ) => {
-  if (agoraType === 'tadak') {
+  if (agoraType === PAGE_NAME.tadak) {
     return async (user: IAgoraRTCRemoteUser, mediaType: 'audio' | 'video') => {
       await client.subscribe(user, mediaType);
       console.log('subscribe success');
@@ -29,7 +30,7 @@ export const userPublished = (
 };
 
 export const userUnpublished = (agoraType: string) => {
-  if (agoraType === 'tadak') {
+  if (agoraType === PAGE_NAME.tadak) {
     return (user: IAgoraRTCRemoteUser, type: 'audio' | 'video') => {
       console.log('unpublished', user, type);
       if (type === 'audio') {

--- a/src/agora/util.ts
+++ b/src/agora/util.ts
@@ -1,0 +1,77 @@
+import { IAgoraRTCClient, IAgoraRTCRemoteUser, ICameraVideoTrack, IMicrophoneAudioTrack } from 'agora-rtc-sdk-ng';
+
+export const userPublished = (
+  agoraType: string,
+  client: IAgoraRTCClient,
+  setState: (user: IAgoraRTCRemoteUser) => void,
+) => {
+  if (agoraType === 'tadak') {
+    return async (user: IAgoraRTCRemoteUser, mediaType: 'audio' | 'video') => {
+      await client.subscribe(user, mediaType);
+      console.log('subscribe success');
+      if (mediaType === 'video') {
+        setState(user);
+      }
+      if (mediaType === 'audio') {
+        user.audioTrack?.play();
+      }
+    };
+  }
+
+  return async (user: IAgoraRTCRemoteUser, mediaType: 'audio' | 'video') => {
+    await client.subscribe(user, mediaType);
+    console.log('subscribe success');
+    if (mediaType === 'audio') {
+      setState(user);
+      user.audioTrack?.play();
+    }
+  };
+};
+
+export const userUnpublished = (agoraType: string) => {
+  if (agoraType === 'tadak') {
+    return (user: IAgoraRTCRemoteUser, type: 'audio' | 'video') => {
+      console.log('unpublished', user, type);
+      if (type === 'audio') {
+        user.audioTrack?.stop();
+      }
+      if (type === 'video') {
+        user.videoTrack?.stop();
+      }
+    };
+  }
+
+  return (user: IAgoraRTCRemoteUser, type: 'audio' | 'video') => {
+    console.log('unpublished', user, type);
+    if (type === 'audio') {
+      user.audioTrack?.stop();
+    }
+  };
+};
+
+export const userChanged = (setState: (user: IAgoraRTCRemoteUser) => void) => {
+  return (user: IAgoraRTCRemoteUser) => {
+    setState(user);
+  };
+};
+
+type ListenTrackType = {
+  track?: IMicrophoneAudioTrack | null;
+  tracks?: [IMicrophoneAudioTrack, ICameraVideoTrack] | null;
+};
+
+export const publishTrack = async (
+  client: IAgoraRTCClient,
+  track: [IMicrophoneAudioTrack, ICameraVideoTrack] | IMicrophoneAudioTrack | null | undefined,
+) => track && (await client.publish(track));
+
+export const muteTrack = async ({ tracks, track }: ListenTrackType) => {
+  if (tracks) {
+    await tracks[1].setEnabled(false);
+    await tracks[0].setEnabled(false);
+  }
+
+  if (track) {
+    await track.setEnabled(false);
+  }
+};

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -81,7 +81,7 @@ interface PostRoom {
 }
 
 export const postRoom = async (body: PostRoom): Promise<HTTPResponse<RoomType>> => {
-  const response = await fetchPost<RoomType>('/api/room', { ...body });
+  const response = await fetchPost<RoomType>('/api/room', { ...body }, true);
   return response;
 };
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,9 +1,15 @@
+import useToggle from '../hooks/useToggle';
+import RectButton from './common/RectButton';
+import MakeRoom from './MakeRoom';
+
 type HeaderProps = {
   userId: string | undefined;
   onClickLogOut: () => void;
 };
 
 export default function Header({ userId, onClickLogOut }: HeaderProps): JSX.Element {
+  const [onModal, toggleOnModal] = useToggle(false);
+
   return (
     <nav className="position(fixed) w(100%) top(0) left(0) p(15)">
       <ul className="hbox w(100%)">
@@ -14,9 +20,14 @@ export default function Header({ userId, onClickLogOut }: HeaderProps): JSX.Elem
         </li>
         <li className="space(30)"></li>
         <li>
+          <RectButton onClick={toggleOnModal} buttonName="방 만들기" />
+        </li>
+        <li className="space(30)"></li>
+        <li>
           <button onClick={onClickLogOut}>로그아웃</button>
         </li>
       </ul>
+      {onModal && <MakeRoom onClickBlackBackground={toggleOnModal} userId={1} />}
     </nav>
   );
 }

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -1,14 +1,16 @@
 import ReactLoading from 'react-loading';
 
 type LoaderProps = {
-  isWholeScreen?: boolean;
   color?: string;
+  displayText?: string;
 };
 
-export default function Loader({ isWholeScreen = false, color = '#75bfff' }: LoaderProps): JSX.Element {
+export default function Loader({ color = '#75bfff', displayText = '' }: LoaderProps): JSX.Element {
   return (
-    <div className={'w(100%) h(20%) text-center ' + isWholeScreen && 'fixed top(0) left(0) height(100%)'}>
+    <div className={'vbox pack text-center'}>
       <ReactLoading type="spin" color={color} />
+      <div className="space(14)"></div>
+      <span className="c(black) opacity(0.5)">{displayText}</span>
     </div>
   );
 }

--- a/src/components/MakeRoom.tsx
+++ b/src/components/MakeRoom.tsx
@@ -4,6 +4,7 @@ import Select from './common/Select';
 import useInput from '../hooks/useInput';
 import { INPUT, PLACEHOLDER_TXT, SELECT_TEXT, RoomNames } from '../utils/constant';
 import { RoomType } from '../types';
+import { postRoom } from '../apis';
 
 type OptionType = {
   value: number;
@@ -18,7 +19,7 @@ export const roomOptions: OptionType[] = [
 ];
 
 type MakeRoomProps = {
-  userId: string;
+  userId: number;
   enterRoom: (uuid: string, roomInfo: RoomType) => void;
 };
 
@@ -46,13 +47,10 @@ const MakeRoom = (props: MakeRoomProps): JSX.Element => {
       roomType,
     };
 
-    const res = await fetch('/api/room', {
-      method: 'POST',
-      body: JSON.stringify(requestBody),
-    });
-    const { data: roomInfo } = await res.json();
-    // 기존 서버에서 유저 인증(토큰)을 요구함
-    // enterRoom(roomInfo.uuid, data);
+    const { isOk, data } = await postRoom(requestBody);
+    if (isOk && data) {
+      enterRoom(data.uuid, data);
+    }
   };
 
   return (

--- a/src/components/MakeRoom.tsx
+++ b/src/components/MakeRoom.tsx
@@ -1,9 +1,13 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
 import RectButton from './common/RectButton';
 import Select from './common/Select';
+import ModalLayout from './layout/ModalLayout';
+
 import useInput from '../hooks/useInput';
 import { INPUT, PLACEHOLDER_TXT, SELECT_TEXT, RoomNames } from '../utils/constant';
-import { RoomType } from '../types';
+import { enterRoom } from '../utils/history';
 import { postRoom } from '../apis';
 
 type OptionType = {
@@ -20,11 +24,12 @@ export const roomOptions: OptionType[] = [
 
 type MakeRoomProps = {
   userId: number;
-  enterRoom: (uuid: string, roomInfo: RoomType) => void;
+  onClickBlackBackground: () => void;
 };
 
 const MakeRoom = (props: MakeRoomProps): JSX.Element => {
-  const { userId, enterRoom } = props;
+  const { userId, onClickBlackBackground } = props;
+  const navigate = useNavigate();
   const [roomTitle, onChangeRoomTitle] = useInput('');
   const [description, onChangeDescription] = useInput('');
   const [roomType, setRoomType] = useState('');
@@ -49,36 +54,38 @@ const MakeRoom = (props: MakeRoomProps): JSX.Element => {
 
     const { isOk, data } = await postRoom(requestBody);
     if (isOk && data) {
-      enterRoom(data.uuid, data);
+      enterRoom(data.uuid, data, navigate);
     }
   };
 
   return (
-    <div className="w(100%) bg(white) p(10) r(10)">
-      <h4 className="font(24) bold text-center">방 만들기</h4>
-      <form className="hbox" onSubmit={onSubmitForm}>
-        <div className="w(80%) p(10) vbox gap(10)">
-          <input
-            type="text"
-            placeholder={PLACEHOLDER_TXT.roomTitle}
-            onChange={onChangeRoomTitle}
-            maxLength={INPUT.roomTitleMaxLen}
-            autoComplete="new-password"
-          />
-          <input
-            type="text"
-            placeholder={PLACEHOLDER_TXT.roomDiscrpt}
-            onChange={onChangeDescription}
-            maxLength={INPUT.roomDescMaxLen}
-            autoComplete="new-password"
-          />
-          <Select name={SELECT_TEXT.roomType} options={roomOptions} onChange={onChangeRoomType} />
-          <Select name={SELECT_TEXT.headCount} options={adminOptions} onChange={onChangeAdminNumber} />
-        </div>
-        <div className="space(30)"></div>
-        <RectButton buttonName="생성" w="15%" h="150" />
-      </form>
-    </div>
+    <ModalLayout onClickBlackBackground={onClickBlackBackground}>
+      <div className="w(100%) bg(white) p(10) r(10)">
+        <h4 className="font(24) bold text-center">방 만들기</h4>
+        <form className="hbox" onSubmit={onSubmitForm}>
+          <div className="w(80%) p(10) vbox gap(10)">
+            <input
+              type="text"
+              placeholder={PLACEHOLDER_TXT.roomTitle}
+              onChange={onChangeRoomTitle}
+              maxLength={INPUT.roomTitleMaxLen}
+              autoComplete="new-password"
+            />
+            <input
+              type="text"
+              placeholder={PLACEHOLDER_TXT.roomDiscrpt}
+              onChange={onChangeDescription}
+              maxLength={INPUT.roomDescMaxLen}
+              autoComplete="new-password"
+            />
+            <Select name={SELECT_TEXT.roomType} options={roomOptions} onChange={onChangeRoomType} />
+            <Select name={SELECT_TEXT.headCount} options={adminOptions} onChange={onChangeAdminNumber} />
+          </div>
+          <div className="space(30)"></div>
+          <RectButton buttonName="생성" w="15%" h="150" />
+        </form>
+      </div>
+    </ModalLayout>
   );
 };
 

--- a/src/components/ModalPortal.tsx
+++ b/src/components/ModalPortal.tsx
@@ -1,0 +1,11 @@
+import { createPortal } from 'react-dom';
+
+type ModalPortalProps = {
+  children: JSX.Element | string;
+};
+
+export default function ModalPortal({ children }: ModalPortalProps) {
+  const modalRoot = document.getElementById('modal-root') as HTMLElement;
+
+  return createPortal(children, modalRoot);
+}

--- a/src/components/agora/ScreenShare.tsx
+++ b/src/components/agora/ScreenShare.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { IAgoraRTCClient, ICameraVideoTrack } from 'agora-rtc-react';
-import { getScreenVideoTrack } from './config';
+import { getScreenVideoTrack } from '../../agora/config';
 
 interface ScreenShareProps {
   client: IAgoraRTCClient;

--- a/src/components/agora/VideoCard.tsx
+++ b/src/components/agora/VideoCard.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState, useRef, useCallback } from 'react';
+import {
+  IRemoteVideoTrack,
+  IRemoteAudioTrack,
+  IMicrophoneAudioTrack,
+  ICameraVideoTrack,
+  AgoraVideoPlayer,
+} from 'agora-rtc-react';
+
+import { SCREEN_SHARE_HEIGHT, SPEAK } from '../../utils/constant';
+import { VIDEO_BOX } from '../../utils/styleConstant';
+
+const videoCardStyle = `pack relative w(${VIDEO_BOX.width}) h(${VIDEO_BOX.width}) r(10) overflow(hidden)`;
+const volumeVisualizerStyle = `w(${VIDEO_BOX.width}) h(${VIDEO_BOX.width}) absolute right(0) b(3/solid/#75bfff) r(10)`;
+
+interface VideoCardProps {
+  videoTrack: ICameraVideoTrack | IRemoteVideoTrack | undefined;
+  audioTrack: IMicrophoneAudioTrack | IRemoteAudioTrack | undefined;
+}
+
+interface DivWithFullscreen extends HTMLDivElement {
+  msRequestFullscreen?: () => void;
+  mozRequestFullScreen?: () => void;
+  webkitRequestFullscreen?: () => void;
+}
+
+const VideoCard = ({ videoTrack, audioTrack }: VideoCardProps): JSX.Element => {
+  const [isSpeak, setIsSpeak] = useState(false);
+  const isInterval = useRef(false);
+  const videoRef = useRef<DivWithFullscreen>(null);
+  const initInterval = useCallback(
+    function () {
+      if (!isInterval.current) {
+        setInterval(() => {
+          if (audioTrack) {
+            setIsSpeak(audioTrack?.getVolumeLevel() > SPEAK.volume);
+          }
+        }, SPEAK.visualTime);
+      }
+      isInterval.current = true;
+    },
+    [isInterval, audioTrack],
+  );
+
+  function openFullscreen() {
+    if (videoRef.current) {
+      if (videoRef.current.requestFullscreen) {
+        videoRef.current.requestFullscreen();
+      } else if (videoRef.current.mozRequestFullScreen) {
+        /* Firefox */
+        videoRef.current.mozRequestFullScreen();
+      } else if (videoRef.current.webkitRequestFullscreen) {
+        /* Chrome, Safari & Opera */
+        videoRef.current.webkitRequestFullscreen();
+      } else if (videoRef.current.msRequestFullscreen) {
+        /* IE/Edge */
+        videoRef.current.msRequestFullscreen();
+      }
+    }
+  }
+
+  useEffect(() => {
+    if (audioTrack) {
+      initInterval();
+    }
+  }, [audioTrack, initInterval]);
+
+  return (
+    <div
+      className={videoCardStyle}
+      onDoubleClick={() => {
+        if (videoTrack?.getCurrentFrameData()?.height === SCREEN_SHARE_HEIGHT) {
+          openFullscreen();
+        }
+      }}
+      ref={videoRef}>
+      {videoTrack && (
+        <AgoraVideoPlayer style={{ height: '100%', width: '100%' }} className="video" videoTrack={videoTrack} />
+      )}
+      {isSpeak && <div className={volumeVisualizerStyle}></div>}
+    </div>
+  );
+};
+
+export default VideoCard;

--- a/src/components/agora/VideoCard.tsx
+++ b/src/components/agora/VideoCard.tsx
@@ -12,8 +12,8 @@ import { FullScreenDivType, openFullScreen } from '../../utils/utils';
 import { VIDEO_BOX } from '../../utils/styleConstant';
 
 const videoCardWrapperStyle = 'vbox';
-const videoCardStyle = `pack relative w(${VIDEO_BOX.width}) h(${VIDEO_BOX.height}) r(10) overflow(hidden) `;
-const videoWaitingCardStyle = `pack relative w(${VIDEO_BOX.width}) h(${VIDEO_BOX.height}) r(10) bg(#30336b) color(white) font(24)`;
+const videoCardStyle = `pack relative w(${VIDEO_BOX.width}) h(${VIDEO_BOX.height}) r(10) clip`;
+const videoWaitingCardStyle = `pack relative w(${VIDEO_BOX.width}) h(${VIDEO_BOX.height}) r(10) bg(#30336b) c(white) font(24)`;
 const volumeVisualizerStyle = `w(${VIDEO_BOX.width}) h(${VIDEO_BOX.height}) absolute right(0) b(3/solid/#75bfff) r(1rem)`;
 const displayNameStyle = 'pack w(100%) font(20) ';
 

--- a/src/components/agora/VideoCard.tsx
+++ b/src/components/agora/VideoCard.tsx
@@ -58,7 +58,7 @@ const VideoCard = ({ videoTrack, audioTrack, displayName }: VideoCardProps): JSX
     <div className={videoCardWrapperStyle}>
       <div className={videoCardStyle} onDoubleClick={onDoubleClickVideoCard} ref={videoRef}>
         {videoTrack && <AgoraVideoPlayer className="w(100%) h(100%)" videoTrack={videoTrack} />}
-        {isSpeak && <div className={volumeVisualizerStyle}></div>}
+        {isSpeak && <div className={volumeVisualizerStyle} />}
       </div>
       <div className={displayNameStyle}>{displayName}</div>
     </div>

--- a/src/components/agora/VideoCard.tsx
+++ b/src/components/agora/VideoCard.tsx
@@ -12,8 +12,9 @@ import { FullScreenDivType, openFullScreen } from '../../utils/utils';
 import { VIDEO_BOX } from '../../utils/styleConstant';
 
 const videoCardWrapperStyle = 'vbox';
-const videoCardStyle = `pack relative w(${VIDEO_BOX.width}) h(${VIDEO_BOX.width}) r(10) overflow(hidden)`;
-const volumeVisualizerStyle = `w(${VIDEO_BOX.width}) h(${VIDEO_BOX.width}) absolute right(0) b(3/solid/#75bfff) r(10)`;
+const videoCardStyle = `pack relative w(${VIDEO_BOX.width}) h(${VIDEO_BOX.height}) r(10) overflow(hidden) `;
+const videoWaitingCardStyle = `pack relative w(${VIDEO_BOX.width}) h(${VIDEO_BOX.height}) r(10) bg(#30336b) color(white) font(24)`;
+const volumeVisualizerStyle = `w(${VIDEO_BOX.width}) h(${VIDEO_BOX.height}) absolute right(0) b(3/solid/#75bfff) r(1rem)`;
 const displayNameStyle = 'pack w(100%) font(20) ';
 
 interface VideoCardProps {
@@ -57,7 +58,11 @@ const VideoCard = ({ videoTrack, audioTrack, displayName }: VideoCardProps): JSX
   return (
     <div className={videoCardWrapperStyle}>
       <div className={videoCardStyle} onDoubleClick={onDoubleClickVideoCard} ref={videoRef}>
-        {videoTrack && <AgoraVideoPlayer className="w(100%) h(100%)" videoTrack={videoTrack} />}
+        {videoTrack ? (
+          <AgoraVideoPlayer className="w(100%) h(100%)" videoTrack={videoTrack} />
+        ) : (
+          <div className={videoWaitingCardStyle}>Video Off</div>
+        )}
         {isSpeak && <div className={volumeVisualizerStyle} />}
       </div>
       <div className={displayNameStyle}>{displayName}</div>

--- a/src/components/agora/VideoCardList.tsx
+++ b/src/components/agora/VideoCardList.tsx
@@ -1,0 +1,41 @@
+import { IAgoraRTCRemoteUser, IMicrophoneAudioTrack, ICameraVideoTrack } from 'agora-rtc-react';
+import { userState } from '../../hooks/recoil/atom';
+import { useRecoilValue } from 'recoil';
+
+import AgoraVideoCard from './VideoCard';
+
+const videoContainerStyle = 'pack h(100%)';
+const videoCardWrapperStyle = 'vbox';
+const userInfoDivStyle = 'pack w(100%) font(20) ';
+const myInfoDivStyle = 'bold';
+const videoGridStyle = 'p(20) grid grid-cols(3) gap(10)';
+
+interface VideoCardListProps {
+  agoraUsers: IAgoraRTCRemoteUser[];
+  tracks: [IMicrophoneAudioTrack, ICameraVideoTrack];
+}
+
+const VideoCardList = ({ agoraUsers, tracks }: VideoCardListProps): JSX.Element => {
+  const [myAudioTrack, myVideoTrack] = tracks;
+  const userInfo = useRecoilValue(userState);
+
+  return (
+    <div className={videoContainerStyle}>
+      <div id="videos" className={videoGridStyle}>
+        <div key={userInfo.nickname} className={videoCardWrapperStyle}>
+          <AgoraVideoCard videoTrack={myVideoTrack} audioTrack={myAudioTrack} />
+          <div className={userInfoDivStyle + myInfoDivStyle}>{userInfo.nickname}(나)</div>
+        </div>
+        {agoraUsers.length > 0 &&
+          agoraUsers.map(({ uid, videoTrack, audioTrack }) => (
+            <div key={uid} className={videoCardWrapperStyle}>
+              <AgoraVideoCard videoTrack={videoTrack} audioTrack={audioTrack} />
+              <div className={userInfoDivStyle}>{decodeURI(String(uid))}</div>
+            </div>
+          ))}
+      </div>
+    </div>
+  );
+};
+
+export default VideoCardList;

--- a/src/components/agora/VideoCardList.tsx
+++ b/src/components/agora/VideoCardList.tsx
@@ -5,9 +5,6 @@ import { useRecoilValue } from 'recoil';
 import AgoraVideoCard from './VideoCard';
 
 const videoContainerStyle = 'pack h(100%)';
-const videoCardWrapperStyle = 'vbox';
-const userInfoDivStyle = 'pack w(100%) font(20) ';
-const myInfoDivStyle = 'bold';
 const videoGridStyle = 'p(20) grid grid-cols(3) gap(10)';
 
 interface VideoCardListProps {
@@ -18,21 +15,25 @@ interface VideoCardListProps {
 const VideoCardList = ({ agoraUsers, tracks }: VideoCardListProps): JSX.Element => {
   const [myAudioTrack, myVideoTrack] = tracks;
   const userInfo = useRecoilValue(userState);
+  const displayName = `${userInfo.nickname}(나)`;
 
   return (
     <div className={videoContainerStyle}>
       <div id="videos" className={videoGridStyle}>
-        <div key={userInfo.nickname} className={videoCardWrapperStyle}>
-          <AgoraVideoCard videoTrack={myVideoTrack} audioTrack={myAudioTrack} />
-          <div className={userInfoDivStyle + myInfoDivStyle}>{userInfo.nickname}(나)</div>
-        </div>
-        {agoraUsers.length > 0 &&
-          agoraUsers.map(({ uid, videoTrack, audioTrack }) => (
-            <div key={uid} className={videoCardWrapperStyle}>
-              <AgoraVideoCard videoTrack={videoTrack} audioTrack={audioTrack} />
-              <div className={userInfoDivStyle}>{decodeURI(String(uid))}</div>
-            </div>
-          ))}
+        <AgoraVideoCard
+          key={userInfo.nickname}
+          videoTrack={myVideoTrack}
+          audioTrack={myAudioTrack}
+          displayName={displayName}
+        />
+        {agoraUsers.map(({ uid, videoTrack, audioTrack }) => (
+          <AgoraVideoCard
+            key={uid}
+            videoTrack={videoTrack}
+            audioTrack={audioTrack}
+            displayName={decodeURI(String(uid))}
+          />
+        ))}
       </div>
     </div>
   );

--- a/src/components/agora/VideoCardList.tsx
+++ b/src/components/agora/VideoCardList.tsx
@@ -3,9 +3,7 @@ import { userState } from '../../hooks/recoil/atom';
 import { useRecoilValue } from 'recoil';
 
 import AgoraVideoCard from './VideoCard';
-
-const videoContainerStyle = 'pack h(100%)';
-const videoGridStyle = 'p(20) grid grid-cols(3) gap(10)';
+const videoContainerStyle = 'pack h(90%)';
 
 interface VideoCardListProps {
   agoraUsers: IAgoraRTCRemoteUser[];
@@ -16,6 +14,7 @@ const VideoCardList = ({ agoraUsers, tracks }: VideoCardListProps): JSX.Element 
   const [myAudioTrack, myVideoTrack] = tracks;
   const userInfo = useRecoilValue(userState);
   const displayName = `${userInfo.nickname}(나)`;
+  const videoGridStyle = `p(20) grid grid-cols(${Math.min(agoraUsers.length + 1, 3)}) gap(10)`;
 
   return (
     <div className={videoContainerStyle}>

--- a/src/components/agora/VideoController.tsx
+++ b/src/components/agora/VideoController.tsx
@@ -1,0 +1,99 @@
+import { useState, useCallback, useEffect } from 'react';
+import { FaMicrophone, FaMicrophoneSlash, FaVideo, FaVideoSlash } from 'react-icons/fa';
+import { MdOutlineExitToApp, MdScreenShare, MdStopScreenShare } from 'react-icons/md';
+import { ICameraVideoTrack, IMicrophoneAudioTrack } from 'agora-rtc-react';
+import { useNavigate } from 'react-router-dom';
+
+import useToggle from '../../hooks/useToggle';
+import { getClient } from '../../agora/config';
+import CircleButton from '../common/CircleButton';
+import ScreenShare from '../../agora/ScreenShare';
+
+const buttonContainerStyle = 'relative';
+const videoControlsStyle = 'fixed pack right(0)';
+const getOutButtonStyle = 'fixed top(0) right(10)';
+
+interface VideoControllerProps {
+  tracks: [IMicrophoneAudioTrack, ICameraVideoTrack];
+  toggleIsStreaming: () => void;
+  uuid: string;
+  ownerId: number | undefined;
+}
+
+const VideoController = ({ tracks, toggleIsStreaming, uuid, ownerId }: VideoControllerProps): JSX.Element => {
+  const navigate = useNavigate();
+  const client = getClient();
+  const [trackState, setTrackState] = useState({ video: false, audio: false });
+  const [isScreenShare, toggleIsScreenShare] = useToggle(false);
+  const [myAudioTrack, myVideoTrack] = tracks;
+
+  const mute = async (type: 'audio' | 'video') => {
+    if (type === 'audio') {
+      await myAudioTrack.setEnabled(!trackState.audio);
+      setTrackState((ps) => {
+        return { ...ps, audio: !ps.audio };
+      });
+    } else if (type === 'video') {
+      await myVideoTrack.setEnabled(!trackState.video);
+      setTrackState((ps) => {
+        return { ...ps, video: !ps.video };
+      });
+      if (trackState.video) await client.publish(myVideoTrack);
+    }
+  };
+
+  const leaveAgoraChannel = useCallback(async () => {
+    await client.leave();
+    client.removeAllListeners();
+    myAudioTrack.close();
+    myVideoTrack.close();
+
+    toggleIsStreaming();
+  }, [client, tracks, toggleIsStreaming]);
+
+  //   useEffect(() => {
+  //     return history.listen(() => {
+  //       if (history.action === 'POP') {
+  //         leaveChannel();
+  //       }
+  //     });
+  //   }, [history, leaveChannel]);
+
+  return (
+    <div className={buttonContainerStyle}>
+      <div className={videoControlsStyle}>
+        <CircleButton
+          icon={trackState.audio ? <FaMicrophone fill="white" /> : <FaMicrophoneSlash />}
+          onClick={() => mute('audio')}
+        />
+        <CircleButton
+          icon={trackState.video ? <FaVideo fill="white" /> : <FaVideoSlash />}
+          onClick={() => mute('video')}
+        />
+        <CircleButton
+          icon={isScreenShare ? <MdScreenShare fill="white" /> : <MdStopScreenShare />}
+          onClick={toggleIsScreenShare}
+        />
+        {isScreenShare && (
+          <ScreenShare
+            client={client}
+            videoTrack={myVideoTrack}
+            trackState={trackState}
+            shutDownScreenShare={toggleIsScreenShare}
+          />
+        )}
+      </div>
+      <div className={getOutButtonStyle}>
+        <CircleButton
+          icon={<MdOutlineExitToApp fill="white" />}
+          onClick={() => {
+            leaveAgoraChannel();
+            navigate('/main', { replace: true });
+          }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default VideoController;

--- a/src/components/agora/VideoController.tsx
+++ b/src/components/agora/VideoController.tsx
@@ -7,11 +7,11 @@ import { useNavigate } from 'react-router-dom';
 import useToggle from '../../hooks/useToggle';
 import { getClient } from '../../agora/config';
 import CircleButton from '../common/CircleButton';
-import ScreenShare from '../../agora/ScreenShare';
+import ScreenShare from './ScreenShare';
 
-const buttonContainerStyle = 'relative';
-const videoControlsStyle = 'fixed pack right(0)';
-const getOutButtonStyle = 'fixed top(0) right(10)';
+const buttonContainerStyle = 'w(100%) h(10%) relative';
+const videoControlsStyle = 'pack';
+const getOutButtonStyle = 'fixed top(0) top(10) right(10)';
 
 interface VideoControllerProps {
   tracks: [IMicrophoneAudioTrack, ICameraVideoTrack];
@@ -49,7 +49,7 @@ const VideoController = ({ tracks, toggleIsStreaming, uuid, ownerId }: VideoCont
     myVideoTrack.close();
 
     toggleIsStreaming();
-  }, [client, tracks, toggleIsStreaming]);
+  }, [client, myAudioTrack, myVideoTrack, toggleIsStreaming]);
 
   //   useEffect(() => {
   //     return history.listen(() => {

--- a/src/components/common/CircleButton/index.tsx
+++ b/src/components/common/CircleButton/index.tsx
@@ -9,7 +9,7 @@ interface CircleButtonProps {
   onClick?: () => void;
 }
 
-const CircleButton = ({ text, icon, className, color, onClick }: CircleButtonProps): JSX.Element => {
+const CircleButton = ({ text, icon, className = '', color, onClick }: CircleButtonProps): JSX.Element => {
   return (
     <button color={color} className={'circle-button ' + className} onClick={onClick}>
       {icon}

--- a/src/components/common/CircleButton/index.tsx
+++ b/src/components/common/CircleButton/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import './style.css';
+
+interface CircleButtonProps {
+  icon?: React.ReactNode;
+  text?: string;
+  className?: string;
+  color?: string;
+  onClick?: () => void;
+}
+
+const CircleButton = ({ text, icon, className, color, onClick }: CircleButtonProps): JSX.Element => {
+  return (
+    <button color={color} className={'circle-button ' + className} onClick={onClick}>
+      {icon}
+      {text}
+    </button>
+  );
+};
+
+export default CircleButton;

--- a/src/components/common/CircleButton/style.css
+++ b/src/components/common/CircleButton/style.css
@@ -7,19 +7,20 @@
   justify-content: center;
   align-items: center;
   margin: 0 24px;
-  width: 50px;
-  height: 50px;
-  font-size: 20px;
+  width: 5rem;
+  height: 5rem;
+  font-size: 2.2rem;
   padding: 5px;
-  background: blue;
+  background: #a29bfe;
+  border: 1px solid rgba(0, 0, 0, 0.1);
   color: white;
 }
 .circle-button:hover {
-  background: blue;
+  background: #ff7675;
   opacity: 0.7;
 }
 .circle-button:active {
-  background: blue;
+  background: #ff7675;
   transform: scale(0.9);
   transition: background 0.1s;
 }

--- a/src/components/common/CircleButton/style.css
+++ b/src/components/common/CircleButton/style.css
@@ -1,0 +1,25 @@
+.circle-button {
+  border: none;
+  cursor: pointer;
+  border-radius: 50%;
+  font-family: 'Noto Sans KR', sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 0 24px;
+  width: 50px;
+  height: 50px;
+  font-size: 20px;
+  padding: 5px;
+  background: blue;
+  color: white;
+}
+.circle-button:hover {
+  background: blue;
+  opacity: 0.7;
+}
+.circle-button:active {
+  background: blue;
+  transform: scale(0.9);
+  transition: background 0.1s;
+}

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { MODAL } from '../../utils/styleConstant';
+
+interface ModalProps {
+  title?: string;
+  children: React.ReactNode;
+  onClickBlackBackground: () => void;
+}
+
+const modalContainerStyle = `w(100%) top(0) block`;
+const blackBackgroundStyle = `w(100vw) h(100vh) top(0) left(0) absolute bg(rgba(0,0,0,0.7)) z(2)`;
+const contentStyle = `pack p(5rem/5rem/4rem/5rem) w(${MODAL.width}) h${MODAL.height} top(20vh) left(calc((100vw - ${MODAL.width})/2)) absolute bg(white) r(10) z(5)`;
+const contentInputStyle = ' .modal-input:c(red)';
+const titleStyle = `font(2.4rem) bold text-center`;
+
+const Modal = ({ onClickBlackBackground, children, title }: ModalProps): JSX.Element => {
+  const onClickContent = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => e.stopPropagation();
+
+  return (
+    <div className={modalContainerStyle}>
+      <div className={blackBackgroundStyle} onClick={onClickBlackBackground}>
+        <div className={contentStyle + contentInputStyle} onClick={onClickContent}>
+          {title && <h4 className={titleStyle}>{title}</h4>}
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/src/components/layout/ModalLayout.tsx
+++ b/src/components/layout/ModalLayout.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { MODAL } from '../../utils/styleConstant';
+import ModalPortal from '../ModalPortal';
 
 interface ModalProps {
   title?: string;
@@ -9,7 +10,7 @@ interface ModalProps {
 
 const modalContainerStyle = `w(100%) top(0) block`;
 const blackBackgroundStyle = `w(100vw) h(100vh) top(0) left(0) absolute bg(rgba(0,0,0,0.7)) z(2)`;
-const contentStyle = `pack p(5rem/5rem/4rem/5rem) w(${MODAL.width}) h${MODAL.height} top(20vh) left(calc((100vw - ${MODAL.width})/2)) absolute bg(white) r(10) z(5)`;
+const contentStyle = `pack p(5rem/5rem/4rem/5rem) w(${MODAL.width}) h${MODAL.height} top(30vh) left(25vw) absolute bg(white) r(10) z(5)`;
 const contentInputStyle = ' .modal-input:c(red)';
 const titleStyle = `font(2.4rem) bold text-center`;
 
@@ -17,14 +18,16 @@ const Modal = ({ onClickBlackBackground, children, title }: ModalProps): JSX.Ele
   const onClickContent = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => e.stopPropagation();
 
   return (
-    <div className={modalContainerStyle}>
-      <div className={blackBackgroundStyle} onClick={onClickBlackBackground}>
-        <div className={contentStyle + contentInputStyle} onClick={onClickContent}>
-          {title && <h4 className={titleStyle}>{title}</h4>}
-          {children}
+    <ModalPortal>
+      <div className={modalContainerStyle}>
+        <div className={blackBackgroundStyle} onClick={onClickBlackBackground}>
+          <div className={contentStyle + contentInputStyle} onClick={onClickContent}>
+            {title && <h4 className={titleStyle}>{title}</h4>}
+            {children}
+          </div>
         </div>
       </div>
-    </div>
+    </ModalPortal>
   );
 };
 

--- a/src/hooks/useAgora.ts
+++ b/src/hooks/useAgora.ts
@@ -18,7 +18,7 @@ type UseAgoraProps = {
 type UseAgoraReturns = {
   agoraUsers: IAgoraRTCRemoteUser[];
   isStreaming: boolean;
-  toggleIsStreaming: React.Dispatch<React.SetStateAction<boolean>>;
+  toggleIsStreaming: () => void;
 };
 
 function useAgora({

--- a/src/hooks/useAgora.ts
+++ b/src/hooks/useAgora.ts
@@ -3,6 +3,7 @@ import { UserType } from '../types';
 import { getClient } from '../agora/config';
 import { IAgoraRTCRemoteUser, ICameraVideoTrack, IMicrophoneAudioTrack } from 'agora-rtc-sdk-ng';
 import { userPublished, userUnpublished, userChanged, muteTrack, publishTrack } from '../agora/util';
+import useToggle from './useToggle';
 
 type UseAgoraProps = {
   agoraAppId: string;
@@ -33,10 +34,10 @@ function useAgora({
 }: UseAgoraProps): UseAgoraReturns {
   const client = getClient();
   const [agoraUsers, setAgoraUsers] = useState<IAgoraRTCRemoteUser[]>([]);
-  const [isStreaming, setIsStreaming] = useState(false);
+  const [isStreaming, toggleIsStreaming] = useToggle(false);
 
   const addUsers = useCallback((user: IAgoraRTCRemoteUser) => {
-    setAgoraUsers((prevUsers) => [...prevUsers, user]);
+    setAgoraUsers((prevUsers) => [...new Set([...prevUsers, user])]);
   }, []);
 
   const removeUsers = useCallback((user: IAgoraRTCRemoteUser) => {
@@ -44,10 +45,6 @@ function useAgora({
       return prevUsers.filter((User) => User.uid !== user.uid);
     });
   }, []);
-
-  const toggleIsStreaming = () => {
-    setIsStreaming((prev) => !prev);
-  };
 
   const listenAgora = useCallback(() => {
     client.on('user-published', userPublished(agoraType, client, addUsers));
@@ -62,7 +59,7 @@ function useAgora({
     await muteTrack({ track, tracks });
 
     toggleIsStreaming();
-  }, [uuid, agoraAppId, agoraToken, client, track, tracks, userInfo]);
+  }, [uuid, agoraAppId, agoraToken, client, track, tracks, userInfo, toggleIsStreaming]);
 
   useEffect(() => {
     if (ready && (track || tracks)) {

--- a/src/hooks/useAgora.ts
+++ b/src/hooks/useAgora.ts
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useState } from 'react';
+import { UserType } from '../types';
+import { useClient } from '../agora/config';
+import { IAgoraRTCRemoteUser, ICameraVideoTrack, IMicrophoneAudioTrack } from 'agora-rtc-sdk-ng';
+import { userPublished, userUnpublished, userChanged, muteTrack, publishTrack } from '../agora/util';
+
+type UseAgoraProps = {
+  agoraAppId: string;
+  agoraToken: string;
+  uuid: string;
+  userInfo: UserType;
+  agoraType: string;
+  ready: boolean;
+  track?: IMicrophoneAudioTrack | null;
+  tracks?: [IMicrophoneAudioTrack, ICameraVideoTrack] | null;
+};
+
+type UseAgoraReturns = {
+  users: IAgoraRTCRemoteUser[];
+  start: boolean;
+  setStart: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+function useTadakAgora({
+  agoraAppId,
+  agoraToken,
+  uuid,
+  userInfo,
+  agoraType,
+  ready,
+  track,
+  tracks,
+}: UseAgoraProps): UseAgoraReturns {
+  const client = useClient();
+  const [users, setUsers] = useState<IAgoraRTCRemoteUser[]>([]);
+  const [start, setStart] = useState(false);
+
+  const addUsers = useCallback((user: IAgoraRTCRemoteUser) => {
+    setUsers((prevUsers) => [...prevUsers, user]);
+  }, []);
+
+  const removeUsers = useCallback((user: IAgoraRTCRemoteUser) => {
+    setUsers((prevUsers) => {
+      return prevUsers.filter((User) => User.uid !== user.uid);
+    });
+  }, []);
+
+  const listenAgora = useCallback(() => {
+    client.on('user-published', userPublished(agoraType, client, addUsers));
+    client.on('user-unpublished', userUnpublished(agoraType));
+    client.on('user-joined', userChanged(addUsers));
+    client.on('user-left', userChanged(removeUsers));
+  }, [agoraType, client, addUsers, removeUsers]);
+
+  const startAgora = useCallback(async () => {
+    await client.join(agoraAppId, uuid, agoraToken, encodeURI(userInfo.nickname ?? ''));
+    await publishTrack(client, track || tracks);
+    await muteTrack({ track, tracks });
+
+    setStart(true);
+  }, [uuid, agoraAppId, agoraToken, client, track, tracks, userInfo]);
+
+  useEffect(() => {
+    if (ready && (track || tracks)) {
+      listenAgora();
+      startAgora();
+    }
+  }, [listenAgora, startAgora, ready, track, tracks]);
+
+  return { users, start, setStart };
+}
+
+export default useTadakAgora;

--- a/src/hooks/useToggle.ts
+++ b/src/hooks/useToggle.ts
@@ -1,0 +1,12 @@
+import { useCallback, useState } from 'react';
+
+function useToggle(initialState = false): [boolean, () => void] {
+  const [state, setState] = useState(initialState);
+  const toggle = useCallback(() => {
+    setState((prevState) => !prevState);
+  }, []);
+
+  return [state, toggle];
+}
+
+export default useToggle;

--- a/src/index.css
+++ b/src/index.css
@@ -26,9 +26,17 @@ body {
   overflow-wrap: break-word;
   tab-size: 4;
 }
+
 html,
 body {
   height: 100%;
+}
+html {
+  font-size: 62.5%;
+  line-height: 1.285;
+}
+body {
+  font-size: 1.6rem;
 }
 img,
 picture,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,24 +1,17 @@
-import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { RecoilRoot } from 'recoil';
-import reportWebVitals from './reportWebVitals';
 
 import App from './App';
 import './index.css';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
-  <React.StrictMode>
-    <RecoilRoot>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    </RecoilRoot>
-  </React.StrictMode>,
+  // <React.StrictMode>
+  <RecoilRoot>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </RecoilRoot>,
+  // </React.StrictMode>,
 );
-
-// If you want to start measuring performance in your app, pass a function
-// to log results (for example: reportWebVitals(console.log))
-// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-reportWebVitals();

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -4,9 +4,9 @@ import { useRecoilState } from 'recoil';
 
 import Header from '../components/Header';
 import RoomCard from '../components/RoomCard';
-import MakeRoom from '../components/MakeRoom';
 
 import { userState } from '../hooks/recoil/atom';
+import { enterRoom } from '../utils/history';
 import { RoomType } from '../types';
 import { auth } from '../apis/auth';
 import { postLogout } from '../apis';
@@ -27,13 +27,6 @@ export default function Main() {
     setUser({});
     redirectLoginPage();
   }, [redirectLoginPage, setUser]);
-
-  const enterClickedRoom = useCallback(
-    (uuid: string, roomInfo: RoomType) => {
-      navigate(`/room/${uuid}`, { state: roomInfo });
-    },
-    [navigate],
-  );
 
   const fetchRoomList = useCallback(async () => {
     const res = await fetch('/api/room?type=타닥타닥&search=&page=1&take=15');
@@ -66,9 +59,9 @@ export default function Main() {
         return;
       }
 
-      enterClickedRoom(uuid, clickedRoomInfo);
+      enterRoom(uuid, clickedRoomInfo, navigate);
     },
-    [rooms, fetchClickedRoomInfoByUuid, canIEnterRoom, enterClickedRoom],
+    [rooms, fetchClickedRoomInfoByUuid, canIEnterRoom, navigate],
   );
 
   useEffect(() => {
@@ -89,7 +82,6 @@ export default function Main() {
   return (
     <main className="vbox">
       <Header onClickLogOut={onClickLogOut} userId={user.nickname} />
-      <MakeRoom userId={user.id as number} enterRoom={enterClickedRoom} />
       <div className="space(30)"></div>
       <hr className="b(1/solid/white)" />
       <div className="space(30)"></div>

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -89,7 +89,7 @@ export default function Main() {
   return (
     <main className="vbox">
       <Header onClickLogOut={onClickLogOut} userId={user.nickname} />
-      <MakeRoom userId={user.nickname as string} enterRoom={enterClickedRoom} />
+      <MakeRoom userId={user.id as number} enterRoom={enterClickedRoom} />
       <div className="space(30)"></div>
       <hr className="b(1/solid/white)" />
       <div className="space(30)"></div>

--- a/src/pages/MiniTadak.tsx
+++ b/src/pages/MiniTadak.tsx
@@ -5,6 +5,7 @@ import { getMicrophoneAndCameraTracks } from '../agora/config';
 import useAgora from '../hooks/useAgora';
 
 import AgoraVideoCardList from '../components/agora/VideoCardList';
+import VideoController from '../components/agora/VideoController';
 import Loader from '../components/Loader';
 
 import { PAGE_NAME } from '../utils/constant';
@@ -16,7 +17,7 @@ type LocationStateType = {
 
 export default function MiniTadak() {
   const {
-    state: { agoraAppId, agoraToken, uuid },
+    state: { agoraAppId, agoraToken, uuid, owner },
   } = useLocation() as LocationStateType;
   const userInfo = useRecoilValue(userState);
   const { ready, tracks } = getMicrophoneAndCameraTracks();
@@ -24,8 +25,21 @@ export default function MiniTadak() {
   const { agoraUsers, isStreaming, toggleIsStreaming } = useAgora(agoraOptions);
 
   if (!isStreaming) {
-    return <Loader isWholeScreen={true} />;
+    return (
+      <div className="w(100%) h(100%) pack">
+        <Loader displayText="방에 입장중입니다..." />
+      </div>
+    );
   }
 
-  return <div>{tracks && <AgoraVideoCardList agoraUsers={agoraUsers} tracks={tracks} />}</div>;
+  return (
+    <div>
+      {tracks && (
+        <>
+          <AgoraVideoCardList agoraUsers={agoraUsers} tracks={tracks} />
+          <VideoController tracks={tracks} toggleIsStreaming={toggleIsStreaming} uuid={uuid} ownerId={owner?.id} />
+        </>
+      )}
+    </div>
+  );
 }

--- a/src/pages/MiniTadak.tsx
+++ b/src/pages/MiniTadak.tsx
@@ -1,10 +1,14 @@
 import { useLocation } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
-import { getMicrophoneAndCameraTracks } from '../agora/config';
 import { userState } from '../hooks/recoil/atom';
+import { getMicrophoneAndCameraTracks } from '../agora/config';
 import useAgora from '../hooks/useAgora';
-import { RoomType } from '../types';
+
+import AgoraVideoCardList from '../components/agora/VideoCardList';
+import Loader from '../components/Loader';
+
 import { PAGE_NAME } from '../utils/constant';
+import { RoomType } from '../types';
 
 type LocationStateType = {
   state: RoomType;
@@ -20,8 +24,8 @@ export default function MiniTadak() {
   const { agoraUsers, isStreaming, toggleIsStreaming } = useAgora(agoraOptions);
 
   if (!isStreaming) {
-    return <div>loading....</div>;
+    return <Loader isWholeScreen={true} />;
   }
 
-  return <div>ready to streaming!!</div>;
+  return <div>{tracks && <AgoraVideoCardList agoraUsers={agoraUsers} tracks={tracks} />}</div>;
 }

--- a/src/pages/MiniTadak.tsx
+++ b/src/pages/MiniTadak.tsx
@@ -33,7 +33,7 @@ export default function MiniTadak() {
   }
 
   return (
-    <div>
+    <div className="w(100%) h(100%)">
       {tracks && (
         <>
           <AgoraVideoCardList agoraUsers={agoraUsers} tracks={tracks} />

--- a/src/pages/MiniTadak.tsx
+++ b/src/pages/MiniTadak.tsx
@@ -1,5 +1,27 @@
-type MiniTadakProps = {};
+import { useLocation } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+import { getMicrophoneAndCameraTracks } from '../agora/config';
+import { userState } from '../hooks/recoil/atom';
+import useAgora from '../hooks/useAgora';
+import { RoomType } from '../types';
+import { PAGE_NAME } from '../utils/constant';
+
+type LocationStateType = {
+  state: RoomType;
+};
 
 export default function MiniTadak() {
-  return <div></div>;
+  const {
+    state: { agoraAppId, agoraToken, uuid },
+  } = useLocation() as LocationStateType;
+  const userInfo = useRecoilValue(userState);
+  const { ready, tracks } = getMicrophoneAndCameraTracks();
+  const agoraOptions = { userInfo, ready, tracks, agoraAppId, agoraToken, uuid, agoraType: PAGE_NAME.tadak };
+  const { agoraUsers, isStreaming, toggleIsStreaming } = useAgora(agoraOptions);
+
+  if (!isStreaming) {
+    return <div>loading....</div>;
+  }
+
+  return <div>ready to streaming!!</div>;
 }

--- a/src/utils/history.ts
+++ b/src/utils/history.ts
@@ -1,0 +1,7 @@
+import { NavigateFunction } from 'react-router-dom';
+
+import { RoomType } from '../types';
+
+export function enterRoom(uuid: string, roomInfo: RoomType, navigate: NavigateFunction) {
+  navigate(`/room/${uuid}`, { state: roomInfo });
+}

--- a/src/utils/styleConstant.ts
+++ b/src/utils/styleConstant.ts
@@ -1,0 +1,97 @@
+import { TOAST_TIME } from './constant';
+
+const WINDOW_HEIGHT = window.innerHeight;
+
+export const CHAT = {
+  listHeight: '84vh',
+  inputHeight: '10vh',
+  inputWidth: '90%',
+  msgWidth: '20rem',
+  fontSize: '1.8rem',
+};
+
+export const FORM = {
+  top: '20%',
+  joinWidth: '40rem',
+  joinHeight: '30rem',
+  loginWidth: '40rem',
+  loginHeight: '30rem',
+  createWidth: '100%',
+  createHeight: '30rem',
+  btnWidth: '16rem',
+  btnBorderRadius: '1rem',
+};
+
+export const MODAL = {
+  width: '65rem',
+  height: '50rem',
+  topPosition: '-15vh',
+};
+
+export const SIDEBAR = {
+  minWidth: '29rem',
+  height: '100vh',
+  zIndex: 10,
+  userNicknameMaxWidth: '100px',
+  RoomBottomMenuHeight: '100%',
+};
+
+export const CAMPER_ICON = {
+  width: '5rem',
+  height: '5rem',
+  borderRadius: '3rem',
+};
+
+export const USER_AVATAR = {
+  width: '3rem',
+  height: '3rem',
+};
+
+export const VIDEO_BOX = {
+  width: '30rem',
+  height: '20rem',
+  borderRadius: '3rem',
+};
+
+export const ROOM_CARD = {
+  width: '20rem',
+  height: '15rem',
+};
+
+export const GRASS = {
+  containerHeight: '18vh',
+  width: `${WINDOW_HEIGHT / 800}rem`,
+  height: `${WINDOW_HEIGHT / 800}rem`,
+  gridGap: '0.3rem',
+  legendFontSize: '3rem',
+  rowNumbers: 7,
+  columnNumbers: 53,
+};
+
+export const TOAST = {
+  width: '38rem',
+  height: '4rem',
+  second: `${TOAST_TIME / 1000}.2s`,
+  topPosition: '10vh',
+};
+
+export const SEARCH_BAR = {
+  initBtn: { fill: 'grey', fontSize: '2.2rem', cursor: 'pointer' },
+};
+
+export const PAGE_TITLE = {
+  mainFontSize: '15rem',
+  profileFontSize: '8rem',
+  profileHeight: '10vh',
+};
+
+export const PROFILE = {
+  containerHeight: '65vh',
+  avatarWidth: '16rem',
+  avatarHeight: '16rem',
+  btnBorderRadius: '1rem',
+  infoCardMinWidth: '20rem',
+  infoCardWidth: '60rem',
+  infoFontSize: '3rem',
+  legendFontSize: '2.3rem',
+};

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -128,3 +128,26 @@ export const drawLineChartDots = (
   });
   ctx.stroke();
 };
+
+export interface FullScreenDivType extends HTMLDivElement {
+  msRequestFullscreen?: () => void;
+  mozRequestFullScreen?: () => void;
+  webkitRequestFullscreen?: () => void;
+}
+
+export function openFullScreen(myRef: React.RefObject<FullScreenDivType>) {
+  if (myRef.current) {
+    if (myRef.current.requestFullscreen) {
+      myRef.current.requestFullscreen();
+    } else if (myRef.current.mozRequestFullScreen) {
+      /* Firefox */
+      myRef.current.mozRequestFullScreen();
+    } else if (myRef.current.webkitRequestFullscreen) {
+      /* Chrome, Safari & Opera */
+      myRef.current.webkitRequestFullscreen();
+    } else if (myRef.current.msRequestFullscreen) {
+      /* IE/Edge */
+      myRef.current.msRequestFullscreen();
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -18,9 +14,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "downlevelIteration": true
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
- 기존 컴포넌트에 종속된 아고라코드를 useAgora 훅으로 분리
- 인증된 유저가, 방 생성후 생성된 응답 데이터 기반으로 아고라 연동
- 메인페이지에 열려 있는 방 클릭시 방 입장 가능.
- 기존의 컴포넌트 재활용 및 className 기반 스타일 간소화.
- 모달 컴포넌트 생성
- Portal을 통해 root 엘리먼트의 형제 modal-root 엘리먼트에 모달을 띄우도록 개선.