### PR TITLE
메인 방 탭, 검색바 추가, 방목록 요청 개선, 로그인유저 화면 개선

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
 
 import MainLayout from 'src/components/layout/MainLayout';
@@ -12,9 +12,11 @@ import { getUserByToken, PostLoginResponse } from 'src/apis';
 import { userState } from 'src/hooks/recoil/user/atom';
 import afterFetcher from './apis/afterFetcher';
 import { useToast } from './hooks/useToast';
-import { TOAST_MESSAGE } from './utils/constant';
+import { PATH, TOAST_MESSAGE } from './utils/constant';
+import { isAuthPage } from './utils/history';
 
 function App() {
+  const location = useLocation();
   const navigate = useNavigate();
   const setUser = useSetRecoilState(userState);
   const { errorToast } = useToast();
@@ -27,25 +29,27 @@ function App() {
       onSuccess: (data: PostLoginResponse) => {
         auth.setAccessToken(data.token);
         setUser(data.userInfo);
-        navigate('/main');
+        navigate(PATH.main);
       },
       onError: () => {
         errorToast(TOAST_MESSAGE.invalidToken);
-        navigate('/');
+        navigate(PATH.login);
       },
     });
   }, [navigate, setUser, errorToast]);
 
   useEffect(() => {
     if (!LocalStorage.validateAuthFlag()) {
-      navigate('/');
+      if (!isAuthPage(location.pathname)) {
+        navigate(PATH.login);
+      }
       return;
     }
 
     if (!auth.hasAccessToken()) {
       getUser();
     }
-  }, [getUser, navigate]);
+  }, [getUser, navigate, location]);
 
   return (
     <div className="App">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,32 +4,48 @@ import { useSetRecoilState } from 'recoil';
 
 import MainLayout from 'src/components/layout/MainLayout';
 import Router from 'src/components/Router';
+import Toast from 'src/components/Toast';
 
 import { auth } from 'src/apis/auth';
 import { LocalStorage } from 'src/utils/localStorage';
-import { getUserByToken } from 'src/apis';
+import { getUserByToken, PostLoginResponse } from 'src/apis';
 import { userState } from 'src/hooks/recoil/user/atom';
-import Toast from 'src/components/Toast';
+import afterFetcher from './apis/afterFetcher';
+import { useToast } from './hooks/useToast';
+import { TOAST_MESSAGE } from './utils/constant';
 
 function App() {
   const navigate = useNavigate();
   const setUser = useSetRecoilState(userState);
+  const { errorToast } = useToast();
 
   const getUser = useCallback(async () => {
-    const { isOk, data } = await getUserByToken();
-    if (isOk && data) {
-      auth.setAccessToken(data.token);
-      setUser(data.userInfo);
-      navigate('/main');
-    }
-  }, [navigate, setUser]);
+    const fetchResult = await getUserByToken();
+
+    await afterFetcher({
+      fetchResult,
+      onSuccess: (data: PostLoginResponse) => {
+        auth.setAccessToken(data.token);
+        setUser(data.userInfo);
+        navigate('/main');
+      },
+      onError: () => {
+        errorToast(TOAST_MESSAGE.invalidToken);
+        navigate('/');
+      },
+    });
+  }, [navigate, setUser, errorToast]);
 
   useEffect(() => {
-    if (!LocalStorage.validateAuthFlag()) return;
+    if (!LocalStorage.validateAuthFlag()) {
+      navigate('/');
+      return;
+    }
+
     if (!auth.hasAccessToken()) {
       getUser();
     }
-  }, [getUser]);
+  }, [getUser, navigate]);
 
   return (
     <div className="App">

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -92,7 +92,7 @@ interface GetRoomQueryObj {
   page: number;
 }
 
-interface ResponseGetRoomData {
+export interface ResponseGetRoomData {
   pageTotal: number;
   results: RoomType[];
   total: number;

--- a/src/components/MakeRoom.tsx
+++ b/src/components/MakeRoom.tsx
@@ -4,6 +4,7 @@ import { useRecoilState } from 'recoil';
 import RectButton from './common/RectButton';
 import Select from './common/Select';
 import ModalLayout from './layout/ModalLayout';
+import Input from './common/Input';
 
 import useRecoilInput from 'src/hooks/useRecoilInput';
 import makeRoomState from 'src/hooks/recoil/modal/makeRoom/atom';
@@ -75,7 +76,8 @@ const MakeRoom = (props: MakeRoomProps): JSX.Element => {
         <h4 className="font(24) bold text-center">방 만들기</h4>
         <form className="hbox" onSubmit={onSubmitForm}>
           <div className="w(80%) p(10) vbox gap(10)">
-            <input
+            <Input
+              name="제목"
               type="text"
               placeholder={PLACEHOLDER_TXT.roomTitle}
               onChange={onChangeRoomTitle}
@@ -83,7 +85,8 @@ const MakeRoom = (props: MakeRoomProps): JSX.Element => {
               autoComplete="new-password"
               value={roomTitle}
             />
-            <input
+            <Input
+              name="설명"
               type="text"
               placeholder={PLACEHOLDER_TXT.roomDiscrpt}
               onChange={onChangeDescription}

--- a/src/components/RoomCard.tsx
+++ b/src/components/RoomCard.tsx
@@ -15,7 +15,7 @@ export default memo(function RoomCard({
 }: RoomCardProps) {
   return (
     <div
-      className="room-card w(250) h(150) vbox bg(white) r(15) p(15) cursor(pointer) hover:bg(#74b9ff) "
+      className="room-card w(250) h(150) vbox bg(#ecf0f1) r(15) p(15) cursor(pointer) hover:bg(#74b9ff) "
       data-card-idx={cardIdx}>
       <h4 className="bold font(18)">{title}</h4>
       <p>{description}</p>

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -5,13 +5,15 @@ import Join from 'src/pages/Join';
 import Main from 'src/pages/Main';
 import MiniTadak from 'src/pages/MiniTadak';
 
+import { PATH } from 'src/utils/constant';
+
 export default function Router() {
   return (
     <Routes>
-      <Route path="/" element={<Login />} />
-      <Route path="/join" element={<Join />} />
-      <Route path="/main" element={<Main />} />
-      <Route path="/room/:uuid" element={<MiniTadak />} />
+      <Route path={PATH.login} element={<Login />} />
+      <Route path={PATH.join} element={<Join />} />
+      <Route path={PATH.main} element={<Main />} />
+      <Route path={PATH.minitadak} element={<MiniTadak />} />
     </Routes>
   );
 }

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -11,7 +11,7 @@ function SearchBar({ search, onChange, onReset }: SearchBarProps): JSX.Element {
   const onSubmitForm = (e: React.FormEvent<HTMLFormElement>) => e.preventDefault();
 
   return (
-    <form className="pack relative" onSubmit={onSubmitForm}>
+    <form className="ml(30) pack relative" onSubmit={onSubmitForm}>
       <input
         type="text"
         onChange={onChange}

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,0 +1,27 @@
+import { TiDelete } from 'react-icons/ti';
+import { SEARCH_BAR } from 'src/utils/styleConstant';
+
+interface SearchBarProps {
+  search: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+  onReset: () => void;
+}
+
+function SearchBar({ search, onChange, onReset }: SearchBarProps): JSX.Element {
+  const onSubmitForm = (e: React.FormEvent<HTMLFormElement>) => e.preventDefault();
+
+  return (
+    <form className="pack relative" onSubmit={onSubmitForm}>
+      <input
+        type="text"
+        onChange={onChange}
+        value={search}
+        placeholder="방 제목을 검색하세요."
+        className="font(1.8rem) w(100%) "
+      />
+      <TiDelete className="hover:opacity(0.8)" style={SEARCH_BAR.initBtn} onClick={onReset} />
+    </form>
+  );
+}
+
+export default SearchBar;

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -1,0 +1,25 @@
+export interface InputProps {
+  name: string;
+  type: string;
+  placeholder: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+  children?: React.ReactNode;
+  maxLength: number;
+  autoComplete?: string;
+  value: string;
+}
+
+const inputStyle = 'w(85%) h(28) pack c(black) placeholder(black)';
+
+const Input = (props: InputProps): JSX.Element => {
+  const { name } = props;
+
+  return (
+    <div className="hbox space-between w(100%)">
+      <label htmlFor={name}>{name}</label>
+      <input className={inputStyle} id={name} {...props} />
+    </div>
+  );
+};
+
+export default Input;

--- a/src/components/common/Select.tsx
+++ b/src/components/common/Select.tsx
@@ -8,14 +8,15 @@ type OptionProps = {
 type SelectProps = {
   name: string;
   options: OptionProps[];
+  selected: string | number;
   onChange?: (e: React.ChangeEvent<HTMLSelectElement>) => void;
 };
 
 const selectStyle = 'w(100%) h(28) pack border(1px/solid/grey) br(10) c(black) placeholder(black)';
 
-const Select = ({ name, options, onChange }: SelectProps): JSX.Element => {
+const Select = ({ name, options, selected, onChange }: SelectProps): JSX.Element => {
   return (
-    <select className={selectStyle} onChange={onChange} defaultValue="">
+    <select className={selectStyle} onChange={onChange} defaultValue={selected}>
       <option value="">{name} 선택</option>
       {options.map(({ value, label }, idx) => (
         <option key={idx} value={value} className="c(black)">

--- a/src/components/common/Select.tsx
+++ b/src/components/common/Select.tsx
@@ -12,18 +12,21 @@ type SelectProps = {
   onChange?: (e: React.ChangeEvent<HTMLSelectElement>) => void;
 };
 
-const selectStyle = 'w(100%) h(28) pack border(1px/solid/grey) br(10) c(black) placeholder(black)';
+const selectStyle = 'w(85%) h(28) pack c(black) placeholder(black)';
 
 const Select = ({ name, options, selected, onChange }: SelectProps): JSX.Element => {
   return (
-    <select className={selectStyle} onChange={onChange} defaultValue={selected}>
-      <option value="">{name} 선택</option>
-      {options.map(({ value, label }, idx) => (
-        <option key={idx} value={value} className="c(black)">
-          {label}
-        </option>
-      ))}
-    </select>
+    <div className="hbox space-between w(100%)">
+      <label htmlFor={name}>{name}</label>
+      <select id={name} className={selectStyle} onChange={onChange} defaultValue={selected}>
+        <option value="">{name} 선택</option>
+        {options.map(({ value, label }, idx) => (
+          <option key={idx} value={value} className="c(black)">
+            {label}
+          </option>
+        ))}
+      </select>
+    </div>
   );
 };
 

--- a/src/components/common/Tab.tsx
+++ b/src/components/common/Tab.tsx
@@ -1,0 +1,18 @@
+export interface TabProps {
+  text?: string;
+  isActive: boolean;
+  onClick?: () => void;
+  children?: React.ReactNode;
+}
+
+const tabStyle = `w(50%) font(1.8rem) p(10) text-center pointer bg(transparent) hover:bg(grey)`;
+const activeTabStyle = ` bb(3px/solid/#0984E3)`;
+
+const Tab = ({ text, isActive, onClick, children }: TabProps): JSX.Element => (
+  <div onClick={onClick} className={tabStyle + (isActive ? activeTabStyle : '')}>
+    {text}
+    {children}
+  </div>
+);
+
+export default Tab;

--- a/src/components/common/Tab.tsx
+++ b/src/components/common/Tab.tsx
@@ -5,7 +5,7 @@ export interface TabProps {
   children?: React.ReactNode;
 }
 
-const tabStyle = `w(50%) font(1.8rem) p(10) text-center pointer bg(transparent) hover:bg(grey)`;
+const tabStyle = `w(25%) font(1.8rem) p(10) text-center pointer bg(transparent) hover:bg(grey)`;
 const activeTabStyle = ` bb(3px/solid/#0984E3)`;
 
 const Tab = ({ text, isActive, onClick, children }: TabProps): JSX.Element => (

--- a/src/components/common/Tab.tsx
+++ b/src/components/common/Tab.tsx
@@ -5,7 +5,7 @@ export interface TabProps {
   children?: React.ReactNode;
 }
 
-const tabStyle = `w(25%) font(1.8rem) p(10) text-center pointer bg(transparent) hover:bg(grey)`;
+const tabStyle = `w(50%) font(1.8rem) p(10) text-center pointer bg(transparent) hover:bg(#c7ecee)`;
 const activeTabStyle = ` bb(3px/solid/#0984E3)`;
 
 const Tab = ({ text, isActive, onClick, children }: TabProps): JSX.Element => (

--- a/src/hooks/recoil/modal/makeRoom/atom.ts
+++ b/src/hooks/recoil/modal/makeRoom/atom.ts
@@ -1,0 +1,29 @@
+import { atom } from 'recoil';
+
+const activate = atom({
+  key: 'roomModalActivateState',
+  default: false,
+});
+
+const roomTitle = atom({
+  key: 'roomTitleState',
+  default: '',
+});
+
+const description = atom({
+  key: 'descriptionState',
+  default: '',
+});
+
+const roomType = atom({
+  key: 'roomTypeState',
+  default: '',
+});
+
+const maxHeadCount = atom({
+  key: 'maxHeadCountState',
+  default: '',
+});
+
+const makeRoomState = { activate, roomTitle, description, roomType, maxHeadCount };
+export default makeRoomState;

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,25 @@
+import { useState, useEffect } from 'react';
+import { DEBOUNCE } from 'src/utils/constant';
+
+type UseDebounceProps = {
+  value: string;
+  delay?: number;
+};
+
+function useDebounce({ value, delay = DEBOUNCE.time }: UseDebounceProps): string {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}
+
+export default useDebounce;

--- a/src/hooks/useRecoilInput.ts
+++ b/src/hooks/useRecoilInput.ts
@@ -1,0 +1,14 @@
+import React, { useCallback } from 'react';
+import { RecoilState, useRecoilState } from 'recoil';
+
+export default function useInput(initialState: RecoilState<string>): [string, typeof onChange, typeof onReset] {
+  const [input, setInput] = useRecoilState(initialState);
+
+  const onChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => setInput(() => e.target.value),
+    [setInput],
+  );
+  const onReset = useCallback(() => setInput(() => ''), [setInput]);
+
+  return [input, onChange, onReset];
+}

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { useSetRecoilState } from 'recoil';
 import { ToastMessageType, ToastType } from '../types';
 import { TOAST_TIME } from '../utils/constant';
@@ -19,24 +20,33 @@ function delToast(toastId: string) {
 export function useToast(delay = TOAST_TIME): ReturnType {
   const setToastMessage = useSetRecoilState(toastState);
 
-  function toast(type: ToastMessageType, message: string) {
-    const id = Math.random().toString(36).substr(2, 9);
-    const toastMessage = { type, message, id };
+  const toast = useCallback(
+    function (type: ToastMessageType, message: string) {
+      const id = Math.random().toString(36).substr(2, 9);
+      const toastMessage = { type, message, id };
 
-    setToastMessage(addToast(toastMessage));
+      setToastMessage(addToast(toastMessage));
 
-    setTimeout(() => {
-      setToastMessage(delToast(id));
-    }, delay);
-  }
+      setTimeout(() => {
+        setToastMessage(delToast(id));
+      }, delay);
+    },
+    [delay, setToastMessage],
+  );
 
-  function successToast(message: string) {
-    toast('success', message);
-  }
+  const successToast = useCallback(
+    function (message: string) {
+      toast('success', message);
+    },
+    [toast],
+  );
 
-  function errorToast(message: string) {
-    toast('error', message);
-  }
+  const errorToast = useCallback(
+    function (message: string) {
+      toast('error', message);
+    },
+    [toast],
+  );
 
   return { successToast, errorToast };
 }

--- a/src/index.css
+++ b/src/index.css
@@ -100,3 +100,7 @@ input {
 input:focus {
   border: 2px solid #0984e3;
 }
+
+.room-card {
+  box-shadow: rgba(0, 0, 0, 0.15) 0px 5px 15px 0px;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -90,7 +90,8 @@ select {
   animation: fade-in-out 3s ease-in-out;
 }
 
-input {
+input,
+select {
   border: 2px solid rgba(0, 0, 0, 0.3);
   border-radius: 5px;
   padding-left: 5px;

--- a/src/index.css
+++ b/src/index.css
@@ -89,3 +89,14 @@ select {
 #toast-fadeInOut {
   animation: fade-in-out 3s ease-in-out;
 }
+
+input {
+  border: 2px solid rgba(0, 0, 0, 0.3);
+  border-radius: 5px;
+  padding-left: 5px;
+  outline: none;
+}
+
+input:focus {
+  border: 2px solid #0984e3;
+}

--- a/src/pages/Join.tsx
+++ b/src/pages/Join.tsx
@@ -9,11 +9,12 @@ import { postJoin } from 'src/apis';
 import { isEmpty } from 'src/utils/utils';
 import { useToast } from 'src/hooks/useToast';
 import afterFetcher from 'src/apis/afterFetcher';
-import { TOAST_MESSAGE } from 'src/utils/constant';
+import { TOAST_MESSAGE, PATH } from 'src/utils/constant';
 import { ErrorResponse } from 'src/types';
+import { redirectPage } from 'src/utils/history';
 
 const linkOption = {
-  to: '/',
+  to: PATH.login,
   text: '로그인 하러가기',
 };
 
@@ -23,9 +24,7 @@ export default function Join() {
   const [userId, onChangeUserId] = useInput('');
   const [password, onChangePassword] = useInput('');
 
-  const redirectLoginPage = (userId: string) => {
-    navigate('/', { state: userId });
-  };
+  const redirectLoginPage = redirectPage({ navigate, path: PATH.login, replace: true, state: userId });
 
   const onSubmitForm = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -42,7 +41,7 @@ export default function Join() {
     await afterFetcher({
       fetchResult,
       onSuccess: () => {
-        redirectLoginPage(userId);
+        redirectLoginPage();
         toast.successToast(TOAST_MESSAGE.joinSuccess);
       },
       onError: (errorData: ErrorResponse) => {

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -12,11 +12,11 @@ import afterFetcher from 'src/apis/afterFetcher';
 import { auth } from 'src/apis/auth';
 import { userState } from 'src/hooks/recoil/user/atom';
 import { useToast } from 'src/hooks/useToast';
-import { TOAST_MESSAGE } from 'src/utils/constant';
+import { PATH, TOAST_MESSAGE } from 'src/utils/constant';
 import { ErrorResponse } from 'src/types';
 
 const linkOption = {
-  to: '/join',
+  to: PATH.join,
   text: '회원가입 하러가기',
 };
 
@@ -29,7 +29,7 @@ export default function Login() {
   const [password, onChangePassword] = useInput('');
   const { successToast, errorToast } = useToast();
 
-  const goToMain = () => navigate('/main');
+  const goToMain = () => navigate(PATH.main);
 
   const onSubmitForm = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -17,6 +17,7 @@ import afterFetcher from 'src/apis/afterFetcher';
 import { TAB_NAME } from 'src/utils/constant';
 import { getRoomQueryObj } from 'src/apis/apiUtils';
 import useInput from 'src/hooks/useInput';
+import SearchBar from 'src/components/SearchBar';
 
 const tabWrapperStyle = 'pack mt(1.8rem) w(100%) relative mb(1.8rem)';
 
@@ -25,7 +26,7 @@ export default function Main() {
   const [loading, setLoading] = useState(true);
   const [rooms, setRooms] = useState<RoomType[]>([]);
   const [tabState, setTabState] = useState({ minitadak: true, campfire: false });
-  const [searchStr, onChangeSearchStr] = useInput('');
+  const [searchStr, onChangeSearch, onResetSearch] = useInput('');
   const [user, setUser] = useRecoilState(userState);
   const currentPage = useRef(1);
   const { errorToast } = useToast();
@@ -118,8 +119,10 @@ export default function Main() {
       <div className={tabWrapperStyle}>
         <Tab text={TAB_NAME.minitadak} isActive={tabState.minitadak} onClick={onClickMiniTadakTab} />
         <Tab text={TAB_NAME.campfire} isActive={tabState.campfire} onClick={onClickCampfireTab} />
+        <div className="w(10)" />
+        <SearchBar search={searchStr} onChange={onChangeSearch} onReset={onResetSearch} />
       </div>
-      <section className="hbox gap(10) flex-wrap @w(~450):vpack" onClick={onClickRoomCard}>
+      <section className="h(70vh) scroll no-scrollbar hbox gap(10) flex-wrap @w(~450):vpack" onClick={onClickRoomCard}>
         {rooms.map((room, idx) => (
           <RoomCard key={room.id} cardIdx={idx} {...room} />
         ))}

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -20,6 +20,7 @@ import { TAB_NAME } from 'src/utils/constant';
 import { getRoomQueryObj } from 'src/apis/apiUtils';
 import useInput from 'src/hooks/useInput';
 import useDebounce from 'src/hooks/useDebounce';
+import { LocalStorage } from 'src/utils/localStorage';
 
 const tabWrapperStyle = 'pack mt(1.8rem) w(100%) relative mb(1.8rem) gap(10) @w(~460):vbox';
 
@@ -106,17 +107,9 @@ export default function Main() {
   );
 
   const addNewPage = useCallback(() => {
-    console.log('??');
     currentPage.current += 1;
     getRoomList(debounceSearch);
   }, [getRoomList, debounceSearch]);
-
-  useEffect(() => {
-    if (!auth.hasAccessToken()) {
-      redirectLoginPage();
-      return;
-    }
-  }, [navigate, redirectLoginPage]);
 
   useEffect(() => {
     currentPage.current = 1;

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -118,6 +118,10 @@ export default function Main() {
   }, [navigate, redirectLoginPage]);
 
   useEffect(() => {
+    currentPage.current = 1;
+  }, [tabState]);
+
+  useEffect(() => {
     if (user.nickname) {
       getRoomList('');
     }
@@ -146,10 +150,6 @@ export default function Main() {
 
     return () => roomObserver.disconnect();
   }, [addNewPage, rooms]);
-
-  useEffect(() => {
-    currentPage.current = 1;
-  }, [tabState]);
 
   return (
     <main className="vbox w(80%)">

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -4,6 +4,7 @@ import { useRecoilState } from 'recoil';
 
 import Header from 'src/components/Header';
 import RoomCard from 'src/components/RoomCard';
+import Tab from 'src/components/common/Tab';
 
 import { userState } from 'src/hooks/recoil/user/atom';
 import { useToast } from 'src/hooks/useToast';
@@ -13,13 +14,20 @@ import { auth } from 'src/apis/auth';
 import { getRoomByUuid, postLogout } from 'src/apis';
 import { TOAST_MESSAGE } from 'src/utils/constant';
 import afterFetcher from 'src/apis/afterFetcher';
+import { TAB_NAME } from 'src/utils/constant';
+
+const tabWrapperStyle = 'pack mt(1.8rem) w(100%) relative mb(1.8rem)';
 
 export default function Main() {
   const navigate = useNavigate();
   const [loading, setLoading] = useState(true);
   const [rooms, setRooms] = useState<RoomType[]>([]);
+  const [tabState, setTabState] = useState({ minitadak: true, campfire: false });
   const [user, setUser] = useRecoilState(userState);
   const { errorToast } = useToast();
+
+  const onClickMiniTadakTab = () => setTabState({ minitadak: true, campfire: false });
+  const onClickCampfireTab = () => setTabState({ minitadak: false, campfire: true });
 
   const redirectLoginPage = redirectPage({ navigate, path: '/', replace: true });
 
@@ -87,6 +95,10 @@ export default function Main() {
   return (
     <main className="vbox w(80%)">
       <Header onClickLogOut={onClickLogOut} userId={user.nickname} />
+      <div className={tabWrapperStyle}>
+        <Tab text={TAB_NAME.minitadak} isActive={tabState.minitadak} onClick={onClickMiniTadakTab} />
+        <Tab text={TAB_NAME.campfire} isActive={tabState.campfire} onClick={onClickCampfireTab} />
+      </div>
       <section className="hbox gap(10) flex-wrap @w(~450):vpack" onClick={onClickRoomCard}>
         {rooms.map((room, idx) => (
           <RoomCard key={room.id} cardIdx={idx} {...room} />

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -5,6 +5,8 @@ import { useRecoilState } from 'recoil';
 import Header from 'src/components/Header';
 import RoomCard from 'src/components/RoomCard';
 import Tab from 'src/components/common/Tab';
+import Loader from 'src/components/Loader';
+import SearchBar from 'src/components/SearchBar';
 
 import { userState } from 'src/hooks/recoil/user/atom';
 import { useToast } from 'src/hooks/useToast';
@@ -12,14 +14,16 @@ import { enterRoom, redirectPage } from 'src/utils/history';
 import { ErrorResponse, RoomType } from 'src/types';
 import { auth } from 'src/apis/auth';
 import { getRoom, getRoomByUuid, postLogout, ResponseGetRoomData } from 'src/apis';
-import { TOAST_MESSAGE } from 'src/utils/constant';
+import { INFINITE_SCROLL, TOAST_MESSAGE } from 'src/utils/constant';
 import afterFetcher from 'src/apis/afterFetcher';
 import { TAB_NAME } from 'src/utils/constant';
 import { getRoomQueryObj } from 'src/apis/apiUtils';
 import useInput from 'src/hooks/useInput';
-import SearchBar from 'src/components/SearchBar';
+import useDebounce from 'src/hooks/useDebounce';
 
 const tabWrapperStyle = 'pack mt(1.8rem) w(100%) relative mb(1.8rem)';
+
+let roomObserver: IntersectionObserver;
 
 export default function Main() {
   const navigate = useNavigate();
@@ -27,9 +31,11 @@ export default function Main() {
   const [rooms, setRooms] = useState<RoomType[]>([]);
   const [tabState, setTabState] = useState({ minitadak: true, campfire: false });
   const [searchStr, onChangeSearch, onResetSearch] = useInput('');
+  const debounceSearch = useDebounce({ value: searchStr });
   const [user, setUser] = useRecoilState(userState);
-  const currentPage = useRef(1);
   const { errorToast } = useToast();
+  const currentPage = useRef(1);
+  const endRef = useRef<HTMLDivElement>(null);
 
   const onClickMiniTadakTab = () => setTabState({ minitadak: true, campfire: false });
   const onClickCampfireTab = () => setTabState({ minitadak: false, campfire: true });
@@ -57,7 +63,6 @@ export default function Main() {
         onSuccess: (data: ResponseGetRoomData) => {
           if (page === 1) setRooms([...data.results]);
           else setRooms((preRooms) => [...preRooms, ...data.results]);
-          currentPage.current += 1;
 
           setLoading(false);
         },
@@ -100,6 +105,11 @@ export default function Main() {
     [rooms, canIEnterRoom, errorToast, navigate],
   );
 
+  const addNewPage = useCallback(() => {
+    currentPage.current += 1;
+    getRoomList(debounceSearch);
+  }, [getRoomList, debounceSearch]);
+
   useEffect(() => {
     if (!auth.hasAccessToken()) {
       redirectLoginPage();
@@ -113,6 +123,34 @@ export default function Main() {
     }
   }, [user, getRoomList]);
 
+  useEffect(() => {
+    if (endRef.current?.lastElementChild) {
+      const { lastElementChild } = endRef.current;
+
+      roomObserver = new IntersectionObserver(
+        function (entries, observer) {
+          entries.forEach(function (entry) {
+            if (entry.isIntersecting && rooms.length === currentPage.current * INFINITE_SCROLL.unit) {
+              console.log('good');
+              observer.unobserve(entry.target);
+              addNewPage();
+            }
+          });
+        },
+        {
+          threshold: INFINITE_SCROLL.threshold,
+        },
+      );
+      roomObserver.observe(lastElementChild);
+    }
+
+    return () => roomObserver.disconnect();
+  }, [addNewPage, rooms]);
+
+  useEffect(() => {
+    currentPage.current = 1;
+  }, [tabState]);
+
   return (
     <main className="vbox w(80%)">
       <Header onClickLogOut={onClickLogOut} userId={user.nickname} />
@@ -122,13 +160,20 @@ export default function Main() {
         <div className="w(10)" />
         <SearchBar search={searchStr} onChange={onChangeSearch} onReset={onResetSearch} />
       </div>
-      <section className="h(70vh) scroll no-scrollbar hbox gap(10) flex-wrap @w(~450):vpack" onClick={onClickRoomCard}>
-        {rooms.map((room, idx) => (
-          <RoomCard key={room.id} cardIdx={idx} {...room} />
-        ))}
-        {!loading && (
+      <section
+        ref={endRef}
+        className="h(70vh) scroll no-scrollbar hbox gap(30) flex-wrap @w(~450):vpack"
+        onClick={onClickRoomCard}>
+        {rooms.length ? (
+          rooms.map((room, idx) => <RoomCard key={room.id} cardIdx={idx} {...room} />)
+        ) : (
+          <div className="w(100%) pack">
+            <h2 className="font(2.2rem) c(rgba(0,0,0,0.6))">개설된 방이 없습니다. 😭</h2>
+          </div>
+        )}
+        {loading && (
           <div className="w(100%) pack mt(10)">
-            <div>loading......</div>
+            <Loader displayText="방을 불러오는 중입니다.." />
           </div>
         )}
       </section>

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -21,7 +21,7 @@ import { getRoomQueryObj } from 'src/apis/apiUtils';
 import useInput from 'src/hooks/useInput';
 import useDebounce from 'src/hooks/useDebounce';
 
-const tabWrapperStyle = 'pack mt(1.8rem) w(100%) relative mb(1.8rem)';
+const tabWrapperStyle = 'pack mt(1.8rem) w(100%) relative mb(1.8rem) gap(10) @w(~460):vbox';
 
 let roomObserver: IntersectionObserver;
 
@@ -106,6 +106,7 @@ export default function Main() {
   );
 
   const addNewPage = useCallback(() => {
+    console.log('??');
     currentPage.current += 1;
     getRoomList(debounceSearch);
   }, [getRoomList, debounceSearch]);
@@ -119,13 +120,8 @@ export default function Main() {
 
   useEffect(() => {
     currentPage.current = 1;
-  }, [tabState]);
-
-  useEffect(() => {
-    if (user.nickname) {
-      getRoomList('');
-    }
-  }, [user, getRoomList]);
+    getRoomList(debounceSearch);
+  }, [getRoomList, tabState, debounceSearch]);
 
   useEffect(() => {
     if (endRef.current?.lastElementChild) {
@@ -135,7 +131,6 @@ export default function Main() {
         function (entries, observer) {
           entries.forEach(function (entry) {
             if (entry.isIntersecting && rooms.length === currentPage.current * INFINITE_SCROLL.unit) {
-              console.log('good');
               observer.unobserve(entry.target);
               addNewPage();
             }
@@ -155,14 +150,15 @@ export default function Main() {
     <main className="vbox w(80%)">
       <Header onClickLogOut={onClickLogOut} userId={user.nickname} />
       <div className={tabWrapperStyle}>
-        <Tab text={TAB_NAME.minitadak} isActive={tabState.minitadak} onClick={onClickMiniTadakTab} />
-        <Tab text={TAB_NAME.campfire} isActive={tabState.campfire} onClick={onClickCampfireTab} />
-        <div className="w(10)" />
+        <div className="w(50%) pack @w(~450):w(100%) ">
+          <Tab text={TAB_NAME.minitadak} isActive={tabState.minitadak} onClick={onClickMiniTadakTab} />
+          <Tab text={TAB_NAME.campfire} isActive={tabState.campfire} onClick={onClickCampfireTab} />
+        </div>
         <SearchBar search={searchStr} onChange={onChangeSearch} onReset={onResetSearch} />
       </div>
       <section
         ref={endRef}
-        className="h(70vh) scroll no-scrollbar hbox gap(30) flex-wrap @w(~450):vpack"
+        className="h(70vh) scroll no-scrollbar hbox(top) gap(30) flex-wrap @w(~450):vpack/h(50vh)"
         onClick={onClickRoomCard}>
         {rooms.length ? (
           rooms.map((room, idx) => <RoomCard key={room.id} cardIdx={idx} {...room} />)

--- a/src/utils/constant.ts
+++ b/src/utils/constant.ts
@@ -42,9 +42,10 @@ export const MODAL_NAME = {
 };
 
 export const PATH = {
-  introduction: '/',
+  login: '/',
+  join: '/join',
   main: '/main',
-  tadak: '/room/tadak',
+  minitadak: '/room/minitadak/:uuid',
   campfire: '/room/campfire',
   profile: '/profile',
 };

--- a/src/utils/constant.ts
+++ b/src/utils/constant.ts
@@ -55,6 +55,11 @@ export const PAGE_NAME = {
   campfire: 'CAMPFIRE',
 };
 
+export const TAB_NAME = {
+  minitadak: '미니타닥',
+  campfire: '캠프파이어',
+};
+
 export const ROOM_DESCRIPTION = {
   tadak: '개발 공부를 하는 예비 개발자들이 함께 학습하는 공간이에요.',
   campfire: '모닥불 주변에 모여서 대화를 나누는 아늑한 공간이에요.',

--- a/src/utils/constant.ts
+++ b/src/utils/constant.ts
@@ -80,6 +80,7 @@ export const TOAST_MESSAGE = {
   invalidFormatPwd: '비밀번호는 6자 이상 20자 이하 영문과 숫자를 반드시 포함해야 합니다.',
   invalidFormatNickname: '닉네임은 2자 이상 15자 이하 영문,숫자,한글만 입력할 수 있습니다.',
   invalidPassword: '비밀번호가 틀렸습니다.',
+  invalidToken: '유효하지 않은 접근입니다.',
   notAllowedNonLogin: '로그인 후 입장할 수 있습니다.',
   exceedEntryCapacity: '입장 가능한 인원을 초과했습니다.',
   loginConfirm: '이메일 및 비밀번호를 확인해주세요',

--- a/src/utils/history.ts
+++ b/src/utils/history.ts
@@ -1,6 +1,7 @@
 import { NavigateFunction } from 'react-router-dom';
 
 import { RoomType } from '../types';
+import { PATH } from './constant';
 
 type EnterRoomArgs = {
   uuid: string;
@@ -21,4 +22,10 @@ type RedirectPageArgs = {
 
 export function redirectPage({ navigate, path, replace = false, state }: RedirectPageArgs): Function {
   return () => navigate(path, { replace, state });
+}
+
+export function isAuthPage(pathname: string) {
+  const authPage = [PATH.login, PATH.join];
+
+  return authPage.includes(pathname);
 }


### PR DESCRIPTION
- 메인에 미니타닥/캠프파이어 탭 추가
- 검색바 추가
   - 입력된 검색어 기반 결과목록을 보여줌
- 방 목록을 intersectionobserver를 통해 마지막 요소가 보일 때 새로운 목록을 요청하여 추가하도록 개선
- 방 만들기 모달 비활성화시에도 기존 입력값 유지
- 로그인 유저 새로고침시 나타나는 화면 개선
   - 로그인페이지로 이동후 토큰 검증이 아니라, 기존 페이지에서 인증플래그 검증
   - 인증플래그가 없다면 로그인/회원가입 페이지가 아닐경우 로그인페이지로 이동
   - 인증플래그가 있다면 토큰 검증
   - 토큰이 있다면 유저인증 후 현재페이지로 이동
   - 토큰이 없다면 로그인페이지로 이동